### PR TITLE
add PATCH /admin/users/:id endpoint

### DIFF
--- a/src/features/users/user-controller.ts
+++ b/src/features/users/user-controller.ts
@@ -72,8 +72,29 @@ export class UserController {
       message: 'Admin user created',
       data: result,
     });
-  } catch (error) {
-    next(error);
+    } catch (error) {
+      next(error);
+    }
   }
-}
+
+  static async updateAdminUser(req: UserRequest, res: Response, next: NextFunction) {
+  try {
+    const requesterId = req.user!.id
+    const userId = req.params.id as string
+
+    const result = await UserService.updateAdminUser(
+      requesterId,
+      userId,
+      req.body
+    )
+
+    res.status(200).json({
+      status: 'success',
+      message: 'Admin user updated',
+      data: result,
+    })
+    } catch (error) {
+      next(error)
+    }
+  }
 }

--- a/src/features/users/user-service.ts
+++ b/src/features/users/user-service.ts
@@ -282,4 +282,41 @@ export class UserService {
       role: data.role,
     };
   }
+
+  static async updateAdminUser(
+  requesterId: string,
+  userId: string,
+  data: {
+    role?: 'OUTLET_ADMIN' | 'WORKER' | 'DRIVER'
+    outletId?: string
+    isActive?: boolean
+  }
+  ) {
+  const requester = await prisma.staff.findUnique({
+    where: { userId: requesterId },
+  })
+
+  if (!requester || requester.role !== 'SUPER_ADMIN') {
+    throw new ResponseError(403, 'Forbidden')
+  }
+
+  const staff = await prisma.staff.findUnique({
+    where: { userId },
+  })
+
+  if (!staff) {
+    throw new ResponseError(404, 'User staff not found')
+  }
+
+  const updated = await prisma.staff.update({
+    where: { userId },
+    data: {
+      role: data.role ?? staff.role,
+      outletId: data.outletId ?? staff.outletId,
+      isActive: data.isActive ?? staff.isActive,
+    },
+  })
+
+    return updated
+  }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -16,6 +16,7 @@ apiRouter.get(
   requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
   UserController.getAdminUsers
 );
+
 // Admin - Create user (SUPER_ADMIN only)
 apiRouter.post(
   '/admin/users',
@@ -23,3 +24,11 @@ apiRouter.post(
   requireStaffRole('SUPER_ADMIN'),
   UserController.createAdminUser
 );
+
+// Admin - Update user (SUPER_ADMIN only)
+apiRouter.patch(
+  '/admin/users/:id',
+  requireAuth,
+  requireStaffRole('SUPER_ADMIN'),
+  UserController.updateAdminUser
+)


### PR DESCRIPTION
Add endpoint to update admin user data.

Changes:
- Add updateAdminUser method in UserService
- Add updateAdminUser controller
- Add PATCH /admin/users/:id route
- Allow SUPER_ADMIN to update role, outletId, and isActive for admin users

Tested via Postman.