### PR TITLE
add DELETE /admin/users/:id endpoint

### DIFF
--- a/src/features/users/user-controller.ts
+++ b/src/features/users/user-controller.ts
@@ -97,4 +97,23 @@ export class UserController {
       next(error)
     }
   }
+
+  static async deleteAdminUser(req: UserRequest, res: Response, next: NextFunction) {
+  try {
+    const requesterId = req.user!.id
+    const userId = req.params.id as string
+
+    const result = await UserService.deleteAdminUser(
+      requesterId,
+      userId
+    )
+
+    res.status(200).json({
+      status: 'success',
+      message: result.message,
+    })
+    } catch (error) {
+      next(error)
+    }
+  }
 }

--- a/src/features/users/user-service.ts
+++ b/src/features/users/user-service.ts
@@ -319,4 +319,32 @@ export class UserService {
 
     return updated
   }
+
+  static async deleteAdminUser(requesterId: string, userId: string) {
+  const requester = await prisma.staff.findUnique({
+    where: { userId: requesterId },
+  })
+
+  if (!requester || requester.role !== 'SUPER_ADMIN') {
+    throw new ResponseError(403, 'Forbidden')
+  }
+
+  const staff = await prisma.staff.findUnique({
+    where: { userId },
+  })
+
+  if (!staff) {
+    throw new ResponseError(404, 'User staff not found')
+  }
+
+  await prisma.staff.delete({
+    where: { userId },
+  })
+
+  await prisma.user.delete({
+    where: { id: userId },
+  })
+
+    return { message: 'User deleted successfully' }
+  }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -31,4 +31,12 @@ apiRouter.patch(
   requireAuth,
   requireStaffRole('SUPER_ADMIN'),
   UserController.updateAdminUser
-)
+);
+
+// Admin - Delete user (SUPER_ADMIN only)
+apiRouter.delete(
+  '/admin/users/:id',
+  requireAuth,
+  requireStaffRole('SUPER_ADMIN'),
+  UserController.deleteAdminUser
+);


### PR DESCRIPTION
Implement DELETE /admin/users/:id endpoint for Admin Account Management.

Changes:
- Add deleteAdminUser method in UserService
- Add deleteAdminUser controller
- Add DELETE /admin/users/:id route
- Allow SUPER_ADMIN to delete admin/worker/driver users

Behavior:
- Only SUPER_ADMIN can delete admin users
- Deletes staff record and associated user record

Test:
- Successfully tested using Postman
- Verified deletion removes staff and user from database