### PR TITLE
feat: add address management with region data and geocoding support

### DIFF
--- a/src/features/addresses/address-controller.ts
+++ b/src/features/addresses/address-controller.ts
@@ -1,0 +1,54 @@
+import { Validation } from '@/validations/validation';
+import { AddressValidation } from '@/validations/address-validation';
+import { NextFunction, Response } from 'express';
+import { UserRequest } from '@/types/user-request';
+import { AddressService } from './address-service';
+
+export class AddressController {
+  static async list(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const data = await AddressService.listAddresses(req.user!.id);
+      res.status(200).json({ status: 'success', message: 'Addresses retrieved', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async create(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const input = Validation.validate(AddressValidation.CREATE, req.body);
+      const data = await AddressService.createAddress(req.user!.id, input);
+      res.status(201).json({ status: 'success', message: 'Address created', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async update(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const input = Validation.validate(AddressValidation.UPDATE, req.body);
+      const data = await AddressService.updateAddress(req.user!.id, req.params.id as string, input);
+      res.status(200).json({ status: 'success', message: 'Address updated', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async remove(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      await AddressService.deleteAddress(req.user!.id, req.params.id as string);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async setPrimary(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const data = await AddressService.setPrimary(req.user!.id, req.params.id as string);
+      res.status(200).json({ status: 'success', message: 'Primary address updated', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/addresses/address-model.ts
+++ b/src/features/addresses/address-model.ts
@@ -1,0 +1,47 @@
+import type { Address } from '@/generated/prisma/client';
+
+export type CreateAddressInput = {
+  label: string;
+  street: string;
+  city: string;
+  province: string;
+  latitude: number;
+  longitude: number;
+};
+
+export type UpdateAddressInput = {
+  label?: string;
+  street?: string;
+  city?: string;
+  province?: string;
+  latitude?: number;
+  longitude?: number;
+};
+
+export type AddressResponse = {
+  id: string;
+  userId: string;
+  label: string;
+  street: string;
+  city: string;
+  province: string;
+  latitude: number;
+  longitude: number;
+  isPrimary: boolean;
+  createdAt: Date;
+};
+
+export function toAddressResponse(address: Address): AddressResponse {
+  return {
+    id: address.id,
+    userId: address.userId,
+    label: address.label,
+    street: address.street,
+    city: address.city,
+    province: address.province,
+    latitude: address.latitude,
+    longitude: address.longitude,
+    isPrimary: address.isPrimary,
+    createdAt: address.createdAt,
+  };
+}

--- a/src/features/addresses/address-service.ts
+++ b/src/features/addresses/address-service.ts
@@ -1,0 +1,64 @@
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import {
+  CreateAddressInput,
+  UpdateAddressInput,
+  toAddressResponse,
+} from './address-model';
+
+type AddressClient = Pick<typeof prisma, 'address'>;
+
+export class AddressService {
+  private static async findOwned(client: AddressClient, addressId: string, userId: string) {
+    const address = await client.address.findUnique({ where: { id: addressId } });
+    if (!address) throw new ResponseError(404, 'Address not found');
+    if (address.userId !== userId) throw new ResponseError(403, 'Forbidden');
+    return address;
+  }
+
+  static async listAddresses(userId: string) {
+    const addresses = await prisma.address.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'asc' },
+    });
+    return addresses.map(toAddressResponse);
+  }
+
+  static async createAddress(userId: string, data: CreateAddressInput) {
+    return prisma.$transaction(async (tx) => {
+      const count = await tx.address.count({ where: { userId } });
+      const address = await tx.address.create({
+        data: { userId, ...data, isPrimary: count === 0 },
+      });
+      return toAddressResponse(address);
+    });
+  }
+
+  static async updateAddress(userId: string, addressId: string, data: UpdateAddressInput) {
+    return prisma.$transaction(async (tx) => {
+      await AddressService.findOwned(tx, addressId, userId);
+      const updated = await tx.address.update({ where: { id: addressId }, data });
+      return toAddressResponse(updated);
+    });
+  }
+
+  static async deleteAddress(userId: string, addressId: string) {
+    await prisma.$transaction(async (tx) => {
+      const address = await AddressService.findOwned(tx, addressId, userId);
+      await tx.address.delete({ where: { id: addressId } });
+      if (address.isPrimary) {
+        const oldest = await tx.address.findFirst({ where: { userId }, orderBy: { createdAt: 'asc' } });
+        if (oldest) await tx.address.update({ where: { id: oldest.id }, data: { isPrimary: true } });
+      }
+    });
+  }
+
+  static async setPrimary(userId: string, addressId: string) {
+    return prisma.$transaction(async (tx) => {
+      await AddressService.findOwned(tx, addressId, userId);
+      await tx.address.updateMany({ where: { userId }, data: { isPrimary: false } });
+      const updated = await tx.address.update({ where: { id: addressId }, data: { isPrimary: true } });
+      return toAddressResponse(updated);
+    });
+  }
+}

--- a/src/features/region-data/region-controller.ts
+++ b/src/features/region-data/region-controller.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from 'express';
+import { Validation } from '@/validations/validation';
+import { RegionValidation } from '@/validations/region-validation';
+import { RegionService } from './region-service';
+
+export class RegionController {
+  static async listProvinces(req: Request, res: Response, next: NextFunction) {
+    try {
+      const data = await RegionService.getProvinces();
+      res.status(200).json({ status: 'success', message: 'Provinces retrieved', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async listCities(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { provinceId } = Validation.validate(RegionValidation.GET_CITIES, req.params);
+      const data = await RegionService.getCities(provinceId);
+      res.status(200).json({ status: 'success', message: 'Cities retrieved', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async geocode(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { city, province } = Validation.validate(RegionValidation.GEOCODE, req.query);
+      const data = await RegionService.geocode(city, province);
+      res.status(200).json({ status: 'success', message: 'Geocode successful', data });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/region-data/region-model.ts
+++ b/src/features/region-data/region-model.ts
@@ -1,0 +1,15 @@
+export type Province = {
+  id: number;
+  name: string;
+};
+
+export type City = {
+  id: number;
+  name: string;
+  zipCode: string;
+};
+
+export type GeocodeResult = {
+  latitude: number;
+  longitude: number;
+};

--- a/src/features/region-data/region-service.ts
+++ b/src/features/region-data/region-service.ts
@@ -1,0 +1,17 @@
+import { RajaOngkirClient } from '@/utils/rajaongkir';
+import { OpenCageClient } from '@/utils/opencage';
+import type { Province, City, GeocodeResult } from './region-model';
+
+export class RegionService {
+  static async getProvinces(): Promise<Province[]> {
+    return RajaOngkirClient.getProvinces();
+  }
+
+  static async getCities(provinceId: number): Promise<City[]> {
+    return RajaOngkirClient.getCities(provinceId);
+  }
+
+  static async geocode(city: string, province: string): Promise<GeocodeResult> {
+    return OpenCageClient.geocode(city, province);
+  }
+}

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -74,6 +74,33 @@ export const requireStaffAuth = async (
   }
 };
 
+// Use on customer-only routes. Rejects staff members who might otherwise impersonate customers.
+export const requireCustomerAuth = async (
+  req: UserRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const result = await getSessionUser(req);
+    if (!result) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    const staff = await prisma.staff.findUnique({ where: { userId: result.user.id } });
+    if (staff) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
+    req.user = result.user;
+    req.session = result.session;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
 // Factory: returns a middleware that restricts access to staff with one of the given roles.
 // Usage: requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN')
 export const requireStaffRole = (...roles: StaffRole[]) => {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,14 +1,25 @@
 import express from 'express';
-import { requireAuth, requireStaffRole } from '@/middleware/auth-middleware';
+import { requireAuth, requireCustomerAuth, requireStaffRole } from '@/middleware/auth-middleware';
 import { UserController } from '@/features/users/user-controller';
 import { AdminUserController } from '@/features/admin-users/admin-user-controller';
 import { AdminOrderController } from '@/features/admin-orders/admin-order-controller';
 import { OrderController } from '@/features/orders/order-controller';
-import { requireCustomerAuth } from '@/middleware/auth-middleware';
+import { AddressController } from '@/features/addresses/address-controller';
+import { RegionController } from '@/features/region-data/region-controller';
 
 export const apiRouter = express.Router();
 
 apiRouter.get('/users/me', requireAuth, UserController.getMe);
+
+apiRouter.get('/regions/provinces', requireAuth, RegionController.listProvinces);
+apiRouter.get('/regions/cities/:provinceId', requireAuth, RegionController.listCities);
+apiRouter.get('/regions/geocode', requireAuth, RegionController.geocode);
+
+apiRouter.get('/users/addresses', requireCustomerAuth, AddressController.list);
+apiRouter.post('/users/addresses', requireCustomerAuth, AddressController.create);
+apiRouter.patch('/users/addresses/:id/primary', requireCustomerAuth, AddressController.setPrimary);
+apiRouter.patch('/users/addresses/:id', requireCustomerAuth, AddressController.update);
+apiRouter.delete('/users/addresses/:id', requireCustomerAuth, AddressController.remove);
 
 apiRouter.get('/admin/dashboard', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), UserController.getDashboardStats);
 apiRouter.get('/admin/users', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminUserController.getAdminUsers);

--- a/src/utils/opencage.ts
+++ b/src/utils/opencage.ts
@@ -1,0 +1,31 @@
+import { ResponseError } from '@/error/response-error';
+
+type OpenCageResponse = {
+  total_results: number;
+  results: { geometry: { lat: number; lng: number } }[];
+};
+
+export class OpenCageClient {
+  private static readonly BASE = 'https://api.opencagedata.com/geocode/v1/json';
+  private static get KEY() {
+    const key = process.env.OPENCAGE_API_KEY;
+    if (!key) throw new Error('OPENCAGE_API_KEY is not configured');
+    return key;
+  }
+
+  static async geocode(city: string, province: string): Promise<{ latitude: number; longitude: number }> {
+    const query = encodeURIComponent(`${city},${province},Indonesia`);
+    const url = `${this.BASE}?q=${query}&key=${this.KEY}&limit=1&no_annotations=1`;
+
+    const res = await fetch(url);
+    if (!res.ok) throw new ResponseError(502, 'Geocoding service error');
+
+    const json = await res.json() as OpenCageResponse;
+    if (json.total_results === 0) {
+      throw new ResponseError(422, 'Could not geocode the provided city and province');
+    }
+
+    const { lat, lng } = json.results[0].geometry;
+    return { latitude: lat, longitude: lng };
+  }
+}

--- a/src/utils/rajaongkir.ts
+++ b/src/utils/rajaongkir.ts
@@ -1,0 +1,52 @@
+import { ResponseError } from '@/error/response-error';
+import type { Province, City } from '@/features/region-data/region-model';
+
+// Internal API response shape (snake_case as returned by RajaOngkir)
+type ApiProvince = { id: number; name: string };
+type ApiCity = { id: number; name: string; zip_code: string };
+
+type CacheEntry<T> = { data: T; expiry: number };
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours — Indonesia has 34 provinces, cache is bounded
+const provincesCache: { entry: CacheEntry<Province[]> | null } = { entry: null };
+const citiesCache = new Map<number, CacheEntry<City[]>>();
+
+export class RajaOngkirClient {
+  private static readonly BASE = 'https://rajaongkir.komerce.id/api/v1';
+  private static get KEY() {
+    const key = process.env.RAJAONGKIR_COST_API_KEY;
+    if (!key) throw new Error('RAJAONGKIR_COST_API_KEY is not configured');
+    return key;
+  }
+
+  private static headers() {
+    return { Key: this.KEY, accept: 'application/json' };
+  }
+
+  static async getProvinces(): Promise<Province[]> {
+    const now = Date.now();
+    if (provincesCache.entry && provincesCache.entry.expiry > now) {
+      return provincesCache.entry.data;
+    }
+    const res = await fetch(`${this.BASE}/destination/province`, { headers: this.headers() });
+    if (!res.ok) throw new ResponseError(502, 'RajaOngkir API error');
+    const json = await res.json() as { data: ApiProvince[] };
+    if (!json.data) throw new ResponseError(502, 'RajaOngkir API error');
+    const data: Province[] = json.data.map((p) => ({ id: p.id, name: p.name }));
+    provincesCache.entry = { data, expiry: now + CACHE_TTL_MS };
+    return data;
+  }
+
+  static async getCities(provinceId: number): Promise<City[]> {
+    const now = Date.now();
+    const cached = citiesCache.get(provinceId);
+    if (cached && cached.expiry > now) return cached.data;
+    const res = await fetch(`${this.BASE}/destination/city/${provinceId}`, { headers: this.headers() });
+    if (!res.ok) throw new ResponseError(502, 'RajaOngkir API error');
+    const json = await res.json() as { data: ApiCity[] };
+    if (!json.data) throw new ResponseError(502, 'RajaOngkir API error');
+    const data: City[] = json.data.map((c) => ({ id: c.id, name: c.name, zipCode: c.zip_code }));
+    citiesCache.set(provinceId, { data, expiry: now + CACHE_TTL_MS });
+    return data;
+  }
+}

--- a/src/validations/address-validation.ts
+++ b/src/validations/address-validation.ts
@@ -1,0 +1,33 @@
+import { z, ZodType } from 'zod';
+import type { CreateAddressInput, UpdateAddressInput } from '@/features/addresses/address-model';
+
+const coordsSchema = {
+  latitude: z.number().min(-90).max(90),
+  longitude: z.number().min(-180).max(180),
+};
+
+export class AddressValidation {
+  static readonly CREATE: ZodType<CreateAddressInput> = z.object({
+    label: z.string().min(1).max(50),
+    street: z.string().min(1).max(255),
+    city: z.string().min(1).max(100),
+    province: z.string().min(1).max(100),
+    ...coordsSchema,
+  });
+
+  static readonly UPDATE: ZodType<UpdateAddressInput> = z
+    .object({
+      label: z.string().min(1).max(50).optional(),
+      street: z.string().min(1).max(255).optional(),
+      city: z.string().min(1).max(100).optional(),
+      province: z.string().min(1).max(100).optional(),
+      latitude: coordsSchema.latitude.optional(),
+      longitude: coordsSchema.longitude.optional(),
+    })
+    .refine((d) => Object.values(d).some((v) => v !== undefined), {
+      message: 'At least one field must be provided',
+    })
+    .refine((d) => (d.latitude == null) === (d.longitude == null), {
+      message: 'latitude and longitude must be provided together',
+    });
+}

--- a/src/validations/region-validation.ts
+++ b/src/validations/region-validation.ts
@@ -1,0 +1,15 @@
+import { z, ZodType } from 'zod';
+
+type GetCitiesInput = { provinceId: number };
+type GeocodeInput = { city: string; province: string };
+
+export class RegionValidation {
+  static readonly GET_CITIES: ZodType<GetCitiesInput> = z.object({
+    provinceId: z.coerce.number().int().positive(),
+  });
+
+  static readonly GEOCODE: ZodType<GeocodeInput> = z.object({
+    city: z.string().min(1),
+    province: z.string().min(1),
+  });
+}

--- a/tests/integration/address-routes.test.ts
+++ b/tests/integration/address-routes.test.ts
@@ -1,0 +1,225 @@
+import type { Request, Response } from 'express';
+
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((h: Record<string, string | string[] | undefined>) => h),
+  toNodeHandler: jest.fn(() => (_req: Request, res: Response) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => {
+  const addressMock = {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+  };
+  const userMock = { findUnique: jest.fn() };
+  const staffMock = { findUnique: jest.fn() };
+  return {
+    prisma: {
+      address: addressMock,
+      user: userMock,
+      staff: staffMock,
+      $transaction: jest.fn().mockImplementation(async (cb: (tx: unknown) => unknown) =>
+        cb({ address: addressMock })
+      ),
+    },
+  };
+});
+
+jest.mock('@/utils/auth', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+
+const addr = prisma.address as jest.Mocked<typeof prisma.address>;
+const userMock = prisma.user as jest.Mocked<typeof prisma.user>;
+const staffMock = prisma.staff as jest.Mocked<typeof prisma.staff>;
+const getSession = auth.api.getSession as unknown as jest.Mock;
+
+const mockUser = { id: 'user-1', name: 'Test', email: 'test@example.com' };
+
+const authenticatedAs = (u = mockUser) => {
+  getSession.mockResolvedValue({ user: u });
+  userMock.findUnique.mockResolvedValue(u as never);
+  staffMock.findUnique.mockResolvedValue(null as never); // no Staff record = customer
+};
+
+const makeAddress = (overrides: object = {}) => ({
+  id: 'addr-1',
+  userId: 'user-1',
+  label: 'Home',
+  street: '1 Main St',
+  city: 'Jakarta',
+  province: 'DKI Jakarta',
+  latitude: -6.2,
+  longitude: 106.8,
+  isPrimary: true,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/v1/users/addresses', () => {
+  it('returns 401 when not authenticated', async () => {
+    getSession.mockResolvedValue(null);
+    const res = await request(app).get('/api/v1/users/addresses');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns address list when authenticated', async () => {
+    authenticatedAs();
+    addr.findMany.mockResolvedValue([makeAddress()]);
+    const res = await request(app).get('/api/v1/users/addresses');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].label).toBe('Home');
+  });
+});
+
+describe('POST /api/v1/users/addresses', () => {
+  const validBody = {
+    label: 'Office',
+    street: '2 Work Ave',
+    city: 'Bandung',
+    province: 'Jawa Barat',
+    latitude: -6.9,
+    longitude: 107.6,
+  };
+
+  it('returns 401 when not authenticated', async () => {
+    getSession.mockResolvedValue(null);
+    const res = await request(app).post('/api/v1/users/addresses').send(validBody);
+    expect(res.status).toBe(401);
+  });
+
+  it('creates address and returns 201', async () => {
+    authenticatedAs();
+    addr.count.mockResolvedValue(1);
+    addr.create.mockResolvedValue(makeAddress({ ...validBody, isPrimary: false }));
+    const res = await request(app).post('/api/v1/users/addresses').send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty('id');
+  });
+
+  it('returns 400 when label is missing', async () => {
+    authenticatedAs();
+    const res = await request(app)
+      .post('/api/v1/users/addresses')
+      .send({ ...validBody, label: undefined });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when latitude is out of range', async () => {
+    authenticatedAs();
+    const res = await request(app)
+      .post('/api/v1/users/addresses')
+      .send({ ...validBody, latitude: 200 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('PATCH /api/v1/users/addresses/:id', () => {
+  it('returns 400 when only latitude is sent without longitude', async () => {
+    authenticatedAs();
+    const res = await request(app)
+      .patch('/api/v1/users/addresses/addr-1')
+      .send({ latitude: -6.2 });
+    expect(res.status).toBe(400);
+  });
+
+  it('updates address and returns 200', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(makeAddress() as never);
+    addr.update.mockResolvedValue(makeAddress({ label: 'New Label' }) as never);
+    const res = await request(app)
+      .patch('/api/v1/users/addresses/addr-1')
+      .send({ label: 'New Label' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.label).toBe('New Label');
+  });
+
+  it('returns 404 when address does not exist', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .patch('/api/v1/users/addresses/addr-x')
+      .send({ label: 'X' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when address belongs to another user', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(makeAddress({ userId: 'other-user' }) as never);
+    const res = await request(app)
+      .patch('/api/v1/users/addresses/addr-1')
+      .send({ label: 'X' });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/v1/users/addresses/:id', () => {
+  it('returns 401 when not authenticated', async () => {
+    getSession.mockResolvedValue(null);
+    const res = await request(app).delete('/api/v1/users/addresses/addr-1');
+    expect(res.status).toBe(401);
+  });
+
+  it('deletes address and returns 204', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: false }) as never);
+    addr.delete.mockResolvedValue({} as never);
+    const res = await request(app).delete('/api/v1/users/addresses/addr-1');
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 when address does not exist', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete('/api/v1/users/addresses/addr-x');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/v1/users/addresses/:id/primary', () => {
+  it('sets address as primary and returns 200', async () => {
+    authenticatedAs();
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: false }) as never);
+    addr.updateMany.mockResolvedValue({ count: 1 } as never);
+    addr.update.mockResolvedValue(makeAddress({ isPrimary: true }) as never);
+    const res = await request(app).patch('/api/v1/users/addresses/addr-1/primary');
+    expect(res.status).toBe(200);
+    expect(res.body.data.isPrimary).toBe(true);
+  });
+});
+
+describe('Address routes: staff access denied', () => {
+  const staffRecord = { id: 'staff-1', userId: 'user-1', role: 'WORKER', isActive: true };
+
+  it('returns 403 when a staff member calls GET /users/addresses', async () => {
+    getSession.mockResolvedValue({ user: mockUser });
+    userMock.findUnique.mockResolvedValue(mockUser as never);
+    staffMock.findUnique.mockResolvedValue(staffRecord as never);
+    const res = await request(app).get('/api/v1/users/addresses');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when a staff member calls POST /users/addresses', async () => {
+    getSession.mockResolvedValue({ user: mockUser });
+    userMock.findUnique.mockResolvedValue(mockUser as never);
+    staffMock.findUnique.mockResolvedValue(staffRecord as never);
+    const res = await request(app).post('/api/v1/users/addresses').send({
+      label: 'Office', street: '2 Work Ave', city: 'Bandung', province: 'Jawa Barat',
+      latitude: -6.9, longitude: 107.6,
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/integration/region-routes.test.ts
+++ b/tests/integration/region-routes.test.ts
@@ -1,0 +1,100 @@
+import type { Request, Response } from 'express';
+
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((h: Record<string, string | string[] | undefined>) => h),
+  toNodeHandler: jest.fn(() => (_req: Request, res: Response) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+jest.mock('@/utils/rajaongkir', () => ({
+  RajaOngkirClient: {
+    getProvinces: jest.fn(),
+    getCities: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/opencage', () => ({
+  OpenCageClient: {
+    geocode: jest.fn(),
+  },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+import { RajaOngkirClient } from '@/utils/rajaongkir';
+import { OpenCageClient } from '@/utils/opencage';
+
+const userMock = prisma.user as jest.Mocked<typeof prisma.user>;
+const getSession = auth.api.getSession as unknown as jest.Mock;
+const mockUser = { id: 'user-1', name: 'Test', email: 'test@example.com' };
+
+const authenticatedAs = (u = mockUser) => {
+  getSession.mockResolvedValue({ user: u });
+  userMock.findUnique.mockResolvedValue(u as never);
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/v1/regions/provinces', () => {
+  it('returns 401 when not authenticated', async () => {
+    getSession.mockResolvedValue(null);
+    const res = await request(app).get('/api/v1/regions/provinces');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns provinces list', async () => {
+    authenticatedAs();
+    (RajaOngkirClient.getProvinces as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'DKI Jakarta' },
+    ]);
+    const res = await request(app).get('/api/v1/regions/provinces');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});
+
+describe('GET /api/v1/regions/cities/:provinceId', () => {
+  it('returns 400 when provinceId is not a number', async () => {
+    authenticatedAs();
+    const res = await request(app).get('/api/v1/regions/cities/abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns cities for valid provinceId', async () => {
+    authenticatedAs();
+    (RajaOngkirClient.getCities as jest.Mock).mockResolvedValue([
+      { id: 100, name: 'Jakarta Pusat', zipCode: '10110' },
+    ]);
+    const res = await request(app).get('/api/v1/regions/cities/1');
+    expect(res.status).toBe(200);
+    expect(res.body.data[0]).toHaveProperty('zipCode');
+  });
+});
+
+describe('GET /api/v1/regions/geocode', () => {
+  it('returns 400 when city or province is missing', async () => {
+    authenticatedAs();
+    const res = await request(app).get('/api/v1/regions/geocode?city=Jakarta');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns coordinates for valid city and province', async () => {
+    authenticatedAs();
+    (OpenCageClient.geocode as jest.Mock).mockResolvedValue({ latitude: -6.2, longitude: 106.8 });
+    const res = await request(app).get('/api/v1/regions/geocode?city=Jakarta&province=DKI+Jakarta');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('latitude');
+    expect(res.body.data).toHaveProperty('longitude');
+  });
+});

--- a/tests/unit/address-service.test.ts
+++ b/tests/unit/address-service.test.ts
@@ -1,0 +1,155 @@
+jest.mock('@/application/database', () => {
+  const addressMock = {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+  };
+  return {
+    prisma: {
+      address: addressMock,
+      $transaction: jest.fn().mockImplementation(async (cb: (tx: unknown) => unknown) =>
+        cb({ address: addressMock })
+      ),
+    },
+  };
+});
+
+import { AddressService } from '@/features/addresses/address-service';
+import { ResponseError } from '@/error/response-error';
+import { prisma } from '@/application/database';
+
+const addr = prisma.address as jest.Mocked<typeof prisma.address>;
+
+const makeAddress = (overrides: object = {}) => ({
+  id: 'addr-1',
+  userId: 'user-1',
+  label: 'Home',
+  street: '123 Main St',
+  city: 'Jakarta',
+  province: 'DKI Jakarta',
+  latitude: -6.2,
+  longitude: 106.8,
+  isPrimary: true,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('AddressService.listAddresses', () => {
+  it('returns mapped addresses', async () => {
+    addr.findMany.mockResolvedValue([makeAddress()]);
+    const result = await AddressService.listAddresses('user-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Home');
+  });
+});
+
+describe('AddressService.createAddress', () => {
+  it('sets isPrimary true when no addresses exist', async () => {
+    addr.count.mockResolvedValue(0);
+    addr.create.mockResolvedValue(makeAddress({ isPrimary: true }));
+    const result = await AddressService.createAddress('user-1', {
+      label: 'Home', street: '1 St', city: 'Jakarta', province: 'DKI Jakarta',
+      latitude: -6.2, longitude: 106.8,
+    });
+    expect(result.isPrimary).toBe(true);
+    expect(addr.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ isPrimary: true }) })
+    );
+  });
+
+  it('sets isPrimary false when addresses already exist', async () => {
+    addr.count.mockResolvedValue(2);
+    addr.create.mockResolvedValue(makeAddress({ isPrimary: false }));
+    const result = await AddressService.createAddress('user-1', {
+      label: 'Office', street: '2 St', city: 'Bekasi', province: 'Jawa Barat',
+      latitude: -6.3, longitude: 107.0,
+    });
+    expect(result.isPrimary).toBe(false);
+  });
+});
+
+describe('AddressService.updateAddress', () => {
+  it('updates address when user owns it', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress());
+    addr.update.mockResolvedValue(makeAddress({ label: 'Updated' }));
+    const result = await AddressService.updateAddress('user-1', 'addr-1', { label: 'Updated' });
+    expect(result.label).toBe('Updated');
+  });
+
+  it('throws 404 when address not found', async () => {
+    addr.findUnique.mockResolvedValue(null);
+    await expect(AddressService.updateAddress('user-1', 'addr-x', { label: 'X' }))
+      .rejects.toThrow(ResponseError);
+    await expect(AddressService.updateAddress('user-1', 'addr-x', { label: 'X' }))
+      .rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 403 when user does not own address', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ userId: 'other-user' }));
+    await expect(AddressService.updateAddress('user-1', 'addr-1', { label: 'X' }))
+      .rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('AddressService.deleteAddress', () => {
+  it('deletes address and reassigns primary when deleted address was primary', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: true }));
+    addr.delete.mockResolvedValue({});
+    addr.findFirst.mockResolvedValue(makeAddress({ id: 'addr-2', isPrimary: false }));
+    addr.update.mockResolvedValue({});
+    await AddressService.deleteAddress('user-1', 'addr-1');
+    expect(addr.delete).toHaveBeenCalled();
+    expect(addr.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { isPrimary: true } })
+    );
+  });
+
+  it('deletes non-primary address without reassigning', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: false }));
+    addr.delete.mockResolvedValue({});
+    await AddressService.deleteAddress('user-1', 'addr-1');
+    expect(addr.delete).toHaveBeenCalled();
+    expect(addr.update).not.toHaveBeenCalled();
+  });
+
+  it('deletes primary address with no remaining addresses gracefully', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: true }));
+    addr.delete.mockResolvedValue({});
+    addr.findFirst.mockResolvedValue(null);
+    await AddressService.deleteAddress('user-1', 'addr-1');
+    expect(addr.delete).toHaveBeenCalled();
+    expect(addr.update).not.toHaveBeenCalled();
+  });
+
+  it('throws 403 when user does not own address', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ userId: 'other-user' }));
+    await expect(AddressService.deleteAddress('user-1', 'addr-1'))
+      .rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('AddressService.setPrimary', () => {
+  it('sets address as primary and clears others', async () => {
+    addr.findUnique.mockResolvedValue(makeAddress({ isPrimary: false }));
+    addr.updateMany.mockResolvedValue({ count: 2 });
+    addr.update.mockResolvedValue(makeAddress({ isPrimary: true }));
+    const result = await AddressService.setPrimary('user-1', 'addr-1');
+    expect(result.isPrimary).toBe(true);
+    expect(addr.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { isPrimary: false } })
+    );
+  });
+
+  it('throws 404 when address not found', async () => {
+    addr.findUnique.mockResolvedValue(null);
+    await expect(AddressService.setPrimary('user-1', 'addr-x'))
+      .rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/tests/unit/region-service.test.ts
+++ b/tests/unit/region-service.test.ts
@@ -1,0 +1,47 @@
+jest.mock('@/utils/rajaongkir', () => ({
+  RajaOngkirClient: {
+    getProvinces: jest.fn(),
+    getCities: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/opencage', () => ({
+  OpenCageClient: {
+    geocode: jest.fn(),
+  },
+}));
+
+import { RegionService } from '@/features/region-data/region-service';
+import { RajaOngkirClient } from '@/utils/rajaongkir';
+import { OpenCageClient } from '@/utils/opencage';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('RegionService.getProvinces', () => {
+  it('returns provinces from RajaOngkirClient', async () => {
+    const mockProvinces = [{ id: 1, name: 'DKI Jakarta' }];
+    (RajaOngkirClient.getProvinces as jest.Mock).mockResolvedValue(mockProvinces);
+    const result = await RegionService.getProvinces();
+    expect(result).toEqual(mockProvinces);
+  });
+});
+
+describe('RegionService.getCities', () => {
+  it('returns cities for a given province', async () => {
+    const mockCities = [{ id: 100, name: 'Jakarta Pusat', zipCode: '10110' }];
+    (RajaOngkirClient.getCities as jest.Mock).mockResolvedValue(mockCities);
+    const result = await RegionService.getCities(1);
+    expect(result).toEqual(mockCities);
+    expect(RajaOngkirClient.getCities).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('RegionService.geocode', () => {
+  it('returns coordinates from OpenCageClient', async () => {
+    const mockCoords = { latitude: -6.2, longitude: 106.8 };
+    (OpenCageClient.geocode as jest.Mock).mockResolvedValue(mockCoords);
+    const result = await RegionService.geocode('Jakarta', 'DKI Jakarta');
+    expect(result).toEqual(mockCoords);
+    expect(OpenCageClient.geocode).toHaveBeenCalledWith('Jakarta', 'DKI Jakarta');
+  });
+});


### PR DESCRIPTION
## What changed
- Add customer address CRUD endpoints with primary address management (`GET/POST/PATCH/DELETE /api/v1/users/addresses`)
- Add region data endpoints for province/city lookup and geocoding via RajaOngkir and OpenCage (`GET /api/v1/regions/*`)
- Add `requireCustomerAuth` middleware to restrict address routes to customers only (prevents staff impersonation)

## Why
Customers need to manage their pickup/delivery addresses. Region and geocoding support is required for address validation and nearest-outlet calculation during pickup request creation.

## How to test
- [ ] `npm test -- tests/unit/address-service.test.ts` — all unit tests pass
- [ ] `npm test -- tests/integration/address-routes.test.ts` — all integration tests pass (including 403 for staff access)
- [ ] `npm test -- tests/unit/region-service.test.ts` — region service tests pass
- [ ] `npm test -- tests/integration/region-routes.test.ts` — region route tests pass
- [ ] Authenticated as customer: `POST /api/v1/users/addresses` creates address, first address auto-set as primary
- [ ] Authenticated as staff: `GET /api/v1/users/addresses` returns 403
- [ ] `GET /api/v1/regions/provinces` returns list of Indonesian provinces
- [ ] `GET /api/v1/regions/geocode?city=Bandung&province=Jawa+Barat` returns lat/lng coordinates