### PR TITLE
feat: strengthen auth security with token hashing and password complexity

### DIFF
--- a/src/features/admin-users/admin-user-service.ts
+++ b/src/features/admin-users/admin-user-service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/application/database'
 import { ResponseError } from '@/error/response-error'
 import { sendEmail } from '@/utils/mailer'
+import { createHash } from 'crypto'
 import { v4 as uuid } from 'uuid'
 import {
   CreateAdminUserInput,
@@ -8,6 +9,8 @@ import {
   UpdateAdminUserInput,
   toAdminUserResponse
 } from './admin-user-model'
+
+const hashToken = (token: string) => createHash('sha256').update(token).digest('hex');
 
 // Scopes user query by outlet and role. OUTLET_ADMIN sees only users from their outlet.
 const buildUsersWhere = (outletId: string | null | undefined, role?: string) => {
@@ -75,12 +78,12 @@ const createInviteToken = async (email: string) => {
 
   const token = uuid()
 
-  // Token expires in 1 hour (verification links are single-use and time-limited).
+  // Store hash in DB; return raw token for email. DB compromise cannot yield usable tokens.
   await prisma.verification.create({
     data: {
       id: uuid(),
       identifier: email,
-      value: token,
+      value: hashToken(token),
       expiresAt: new Date(Date.now() + 3600 * 1000)
     }
   })

--- a/src/features/users/user-service.ts
+++ b/src/features/users/user-service.ts
@@ -2,17 +2,22 @@ import { prisma } from '@/application/database';
 import { ResponseError } from '@/error/response-error';
 import { sendEmail } from '@/utils/mailer';
 import bcrypt from 'bcrypt';
+import { createHash } from 'crypto';
 import { v4 as uuid } from 'uuid';
 import { RegisterInput, ResendVerificationInput, SetPasswordInput, toUserResponse } from './user-model';
+
+// Store SHA-256 of the token in the DB; email the raw token.
+// If the verification table is compromised, hashes are useless without the raw token.
+const hashToken = (token: string) => createHash('sha256').update(token).digest('hex');
 
 // Clears any existing tokens for this email before issuing a new one, preventing stale links.
 const createVerificationToken = async (email: string): Promise<string> => {
   await prisma.verification.deleteMany({ where: { identifier: email } });
   const token = uuid();
   await prisma.verification.create({
-    data: { id: uuid(), identifier: email, value: token, expiresAt: new Date(Date.now() + 3600 * 1000) }, // expires in 1 hour
+    data: { id: uuid(), identifier: email, value: hashToken(token), expiresAt: new Date(Date.now() + 3600 * 1000) }, // expires in 1 hour
   });
-  return token;
+  return token; // Return raw token for email delivery; only the hash is persisted.
 };
 
 const sendSetPasswordEmail = (email: string, token: string) => {
@@ -27,7 +32,7 @@ const sendSetPasswordEmail = (email: string, token: string) => {
 
 // Validates token existence and expiry in one query; throws if either check fails.
 const verifyToken = async (token: string) => {
-  const verification = await prisma.verification.findFirst({ where: { value: token } });
+  const verification = await prisma.verification.findFirst({ where: { value: hashToken(token) } });
   if (!verification || verification.expiresAt < new Date()) {
     throw new ResponseError(400, 'Invalid or expired token');
   }
@@ -76,7 +81,8 @@ export class UserService {
     if (!user) return { message: 'Verification email sent' }; // Silent success: avoids leaking whether an email is registered.
 
     const existingAccount = await prisma.account.findFirst({ where: { userId: user.id, providerId: 'credential' } });
-    if (existingAccount) throw new ResponseError(409, 'Account already verified');
+    // Silent success: avoids leaking whether the email is registered and verified.
+    if (existingAccount) return { message: 'Verification email sent' };
 
     const token = await createVerificationToken(data.email);
     sendSetPasswordEmail(data.email, token);

--- a/src/validations/user-validation.ts
+++ b/src/validations/user-validation.ts
@@ -8,16 +8,23 @@ import type {
 export class UserValidation {
   static readonly REGISTER: ZodType<RegisterInput> = z.object({
     name: z.string().min(2),
-    email: z.email(),
+    // Normalize to lowercase to prevent duplicate accounts differing only by case.
+    email: z.email().transform((e) => e.toLowerCase()),
   });
 
   static readonly SET_PASSWORD: ZodType<SetPasswordInput> = z.object({
     token: z.string().min(1),
-    password: z.string().min(8),
+    // Enforce basic complexity: uppercase, lowercase, and digit required.
+    password: z
+      .string()
+      .min(8)
+      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+      .regex(/[0-9]/, 'Password must contain at least one digit'),
   });
 
   static readonly RESEND_VERIFICATION: ZodType<ResendVerificationInput> =
     z.object({
-      email: z.email(),
+      email: z.email().transform((e) => e.toLowerCase()),
     });
 }

--- a/tests/unit/user-service.test.ts
+++ b/tests/unit/user-service.test.ts
@@ -99,7 +99,7 @@ describe('UserService', () => {
       expect(result.message).toBe('Verification email sent');
     });
 
-    it('should throw 409 when user already verified', async () => {
+    it('should return silent success when user already verified', async () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         id: 'user-1',
         email: 'john@example.com',
@@ -109,7 +109,9 @@ describe('UserService', () => {
         providerId: 'credential',
       });
 
-      await expect(UserService.resendVerification({ email: 'john@example.com' })).rejects.toThrow(ResponseError);
+      // Silent success prevents account enumeration (caller cannot tell if account is verified).
+      const result = await UserService.resendVerification({ email: 'john@example.com' });
+      expect(result).toEqual({ message: 'Verification email sent' });
     });
 
     it('should send new verification email when user exists and not verified', async () => {

--- a/tests/unit/user-validation.test.ts
+++ b/tests/unit/user-validation.test.ts
@@ -70,7 +70,7 @@ describe('UserValidation', () => {
 
   describe('SET_PASSWORD schema', () => {
     it('should accept valid set password input', () => {
-      const data = { token: 'token-123', password: 'securepass123' };
+      const data = { token: 'token-123', password: 'Securepass123' };
       const result = Validation.validate(UserValidation.SET_PASSWORD, data);
       expect(result).toEqual(data);
     });
@@ -100,7 +100,7 @@ describe('UserValidation', () => {
     });
 
     it('should accept password with exactly 8 characters', () => {
-      const data = { token: 'token-123', password: 'password' };
+      const data = { token: 'token-123', password: 'Password1' };
       const result = Validation.validate(UserValidation.SET_PASSWORD, data);
       expect(result).toEqual(data);
     });
@@ -127,13 +127,13 @@ describe('UserValidation', () => {
     });
 
     it('should accept token with special characters', () => {
-      const data = { token: 'token-123-!@#$%^&*()', password: 'securepass123' };
+      const data = { token: 'token-123-!@#$%^&*()', password: 'Securepass123' };
       const result = Validation.validate(UserValidation.SET_PASSWORD, data);
       expect(result).toEqual(data);
     });
 
     it('should accept single character token', () => {
-      const data = { token: 'a', password: 'securepass123' };
+      const data = { token: 'a', password: 'Securepass123' };
       const result = Validation.validate(UserValidation.SET_PASSWORD, data);
       expect(result).toEqual(data);
     });
@@ -194,10 +194,11 @@ describe('UserValidation', () => {
       expect(() => Validation.validate(UserValidation.RESEND_VERIFICATION, data)).toThrow();
     });
 
-    it('should accept email with uppercase letters', () => {
+    it('should normalize uppercase email to lowercase', () => {
       const data = { email: 'John@Example.COM' };
       const result = Validation.validate(UserValidation.RESEND_VERIFICATION, data);
-      expect(result).toEqual(data);
+      // Email is normalized to lowercase to prevent duplicate accounts.
+      expect(result).toEqual({ email: 'john@example.com' });
     });
 
     it('should accept email with dot in local part', () => {


### PR DESCRIPTION
## What changed
- Hash verification and invite tokens with SHA-256 before storing in DB; only the raw token is sent via email
- Silent success on `resendVerification` when account is already verified (prevents email enumeration)
- Email normalization: Zod schema lowercases email on register and resend (prevents duplicate accounts via case variation)
- Password complexity: requires at least one uppercase letter, one lowercase letter, and one digit (minimum 8 characters)

## Why
If the verification table were ever compromised, stored token hashes are useless without the raw token. Silent success on resend prevents attackers from probing which emails are registered or verified. Password complexity reduces credential stuffing risk.

## How to test
- [ ] `npm test -- tests/unit/user-service.test.ts` — resend silent success test passes
- [ ] `npm test -- tests/unit/user-validation.test.ts` — email normalization and password complexity tests pass
- [ ] Register a user and inspect the `verification` table — value should be a 64-char hex string, not a plain UUID
- [ ] `POST /api/v1/users/resend-verification` with a verified email — returns 200 `{ message: "Verification email sent" }` (no 409)
- [ ] `POST /api/v1/users/register` with `JOHN@EXAMPLE.COM` — stored email is `john@example.com`
- [ ] Set password with `password123` (no uppercase) — returns 400 validation error