### PR TITLE
feat: improve admin management with security limits and laundry items endpoint

### DIFF
--- a/src/features/admin-orders/admin-order-controller.ts
+++ b/src/features/admin-orders/admin-order-controller.ts
@@ -15,7 +15,7 @@ export class AdminOrderController {
 
       const result = await AdminOrderService.getAdminOrders(req.staff!, {
         page: Number(req.query.page) || 1,
-        limit: Number(req.query.limit) || 10,
+        limit: Math.min(Number(req.query.limit) || 10, 100),
         status: req.query.status as string | undefined,
         outletId: req.query.outletId as string | undefined,
         dateFrom: req.query.dateFrom as string | undefined,
@@ -91,7 +91,7 @@ export class AdminOrderController {
     try {
 
       const page = Number(req.query.page) || 1
-      const limit = Number(req.query.limit) || 10
+      const limit = Math.min(Number(req.query.limit) || 10, 100)
 
       const result = await AdminOrderService.getAdminPickupRequests(
         req.staff!,
@@ -104,6 +104,26 @@ export class AdminOrderController {
         message: 'Pickup requests retrieved successfully',
         data: result.data,
         meta: result.meta
+      })
+
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  static async getLaundryItems(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+
+      const items = await AdminOrderService.getLaundryItems()
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Laundry items retrieved',
+        data: items
       })
 
     } catch (error) {

--- a/src/features/admin-orders/admin-order-model.ts
+++ b/src/features/admin-orders/admin-order-model.ts
@@ -15,3 +15,9 @@ export type GetAdminOrdersQuery = {
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
 };
+
+export type LaundryItemResponse = {
+  id: string;
+  name: string;
+  slug: string;
+};

--- a/src/features/admin-orders/admin-order-service.ts
+++ b/src/features/admin-orders/admin-order-service.ts
@@ -1,7 +1,10 @@
 import { prisma } from '@/application/database'
 import { ResponseError } from '@/error/response-error'
 import { v4 as uuid } from 'uuid'
-import { CreateAdminOrderInput, GetAdminOrdersQuery } from './admin-order-model'
+import { CreateAdminOrderInput, GetAdminOrdersQuery, LaundryItemResponse } from './admin-order-model'
+
+const VALID_ORDER_SORT = ['createdAt', 'totalPrice', 'totalWeightKg'] as const;
+type OrderSortField = typeof VALID_ORDER_SORT[number];
 
 // Simple price calculation. Total = weight × price per kg.
 const calculateOrderPrice = (
@@ -36,8 +39,11 @@ export class AdminOrderService {
 
     const skip = (query.page - 1) * query.limit
     const where = buildOrdersWhere(staff, query)
-    const sortBy = query.sortBy ?? 'createdAt'
-    const sortOrder = query.sortOrder ?? 'desc'
+    // Allowlist sortBy to prevent probing internal field names via Prisma error messages.
+    const sortBy: OrderSortField = VALID_ORDER_SORT.includes(query.sortBy as OrderSortField)
+      ? (query.sortBy as OrderSortField)
+      : 'createdAt'
+    const sortOrder = query.sortOrder === 'asc' ? 'asc' : 'desc'
 
     const orders = await prisma.order.findMany({
       where,
@@ -69,7 +75,10 @@ export class AdminOrderService {
       where: { id: orderId },
       include: {
         pickupRequest: {
-          include: { customerUser: true }
+          include: {
+            // Select only non-sensitive fields; never expose password hashes or tokens.
+            customerUser: { select: { id: true, name: true, email: true, phone: true } }
+          }
         },
         outlet: true,
         items: {
@@ -77,7 +86,7 @@ export class AdminOrderService {
         },
         stationRecords: {
           include: {
-            staff: { include: { user: true } },
+            staff: { include: { user: { select: { id: true, name: true, email: true } } } },
             stationItems: { include: { laundryItem: true } },
             bypassRequests: true
           }
@@ -114,7 +123,8 @@ export class AdminOrderService {
       skip,
       take: limit,
       include: {
-        customerUser: true,
+        // Select only non-sensitive fields; never expose password hashes or tokens.
+        customerUser: { select: { id: true, name: true, email: true, phone: true } },
         outlet: true,
         address: true
       }
@@ -187,5 +197,12 @@ export class AdminOrderService {
     ])
 
     return order
+  }
+
+  static async getLaundryItems(): Promise<LaundryItemResponse[]> {
+    return prisma.laundryItem.findMany({
+      select: { id: true, name: true, slug: true },
+      orderBy: { name: 'asc' },
+    });
   }
 }

--- a/src/features/admin-users/admin-user-controller.ts
+++ b/src/features/admin-users/admin-user-controller.ts
@@ -15,7 +15,7 @@ export class AdminUserController {
 
       const result = await AdminUserService.getAdminUsers(req.staff!, {
         page: Number(req.query.page) || 1,
-        limit: Number(req.query.limit) || 10,
+        limit: Math.min(Number(req.query.limit) || 10, 100),
         role: req.query.role as string | undefined,
         sortBy: req.query.sortBy as string | undefined,
         sortOrder: (req.query.sortOrder as 'asc' | 'desc') || undefined,

--- a/src/features/admin-users/admin-user-service.ts
+++ b/src/features/admin-users/admin-user-service.ts
@@ -12,6 +12,9 @@ import {
 
 const hashToken = (token: string) => createHash('sha256').update(token).digest('hex');
 
+const VALID_USER_SORT = ['createdAt', 'name', 'email'] as const;
+type UserSortField = typeof VALID_USER_SORT[number];
+
 // Scopes user query by outlet and role. OUTLET_ADMIN sees only users from their outlet.
 const buildUsersWhere = (outletId: string | null | undefined, role?: string) => {
   const where: Record<string, unknown> = {}
@@ -24,10 +27,15 @@ const buildUsersWhere = (outletId: string | null | undefined, role?: string) => 
 
 const fetchUsers = async (where: object, page: number, limit: number, sortBy = 'createdAt', sortOrder = 'desc') => {
   const skip = (page - 1) * limit
+  // Allowlist sortBy to prevent probing internal field names via Prisma error messages.
+  const validSortBy: UserSortField = VALID_USER_SORT.includes(sortBy as UserSortField)
+    ? (sortBy as UserSortField)
+    : 'createdAt'
+  const validSortOrder = sortOrder === 'asc' ? 'asc' : 'desc'
   const users = await prisma.user.findMany({
     where,
     include: { staff: true },
-    orderBy: { [sortBy]: sortOrder },
+    orderBy: { [validSortBy]: validSortOrder },
     skip,
     take: limit,
   })
@@ -151,15 +159,17 @@ export class AdminUserService {
       throw new ResponseError(404, 'User staff not found')
     }
 
-    return prisma.staff.update({
+    const updated = await prisma.staff.update({
       where: { userId },
       data: {
         role: data.role ?? staff.role,
         outletId: data.outletId ?? staff.outletId,
         isActive: data.isActive ?? staff.isActive,
         workerType: data.workerType ?? staff.workerType
-      }
+      },
+      include: { user: true }
     })
+    return toAdminUserResponse({ ...updated.user, staff: updated })
   }
 
   static async deleteAdminUser(userId: string) {
@@ -172,13 +182,11 @@ export class AdminUserService {
       throw new ResponseError(404, 'User staff not found')
     }
 
-    await prisma.staff.delete({
-      where: { userId }
-    })
-
-    await prisma.user.delete({
-      where: { id: userId }
-    })
+    // Atomic: if user deletion fails after staff deletion, neither operation persists.
+    await prisma.$transaction([
+      prisma.staff.delete({ where: { userId } }),
+      prisma.user.delete({ where: { id: userId } })
+    ])
 
     return {
       message: 'User deleted successfully'

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -15,5 +15,5 @@ apiRouter.get('/admin/pickup-requests', requireStaffRole('SUPER_ADMIN', 'OUTLET_
 apiRouter.post('/admin/orders', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.createAdminOrder);
 apiRouter.post('/admin/users', requireStaffRole('SUPER_ADMIN'), AdminUserController.createAdminUser);
 apiRouter.patch('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.updateAdminUser);
+apiRouter.get('/admin/laundry-items', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getLaundryItems);
 apiRouter.delete('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.deleteAdminUser);
-

--- a/tests/unit/admin-user-service.test.ts
+++ b/tests/unit/admin-user-service.test.ts
@@ -3,6 +3,8 @@ jest.mock('@/application/database', () => ({
     user: { findUnique: jest.fn(), create: jest.fn(), delete: jest.fn(), findMany: jest.fn(), count: jest.fn() },
     staff: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn() },
     verification: { create: jest.fn(), deleteMany: jest.fn() },
+    // deleteAdminUser wraps staff + user delete in a transaction; execute all ops sequentially.
+    $transaction: jest.fn().mockImplementation(async (ops: Promise<unknown>[]) => Promise.all(ops)),
   },
 }));
 


### PR DESCRIPTION
## What changed
- Cap pagination `limit` at 100 on admin orders and admin users endpoints (prevents DoS via huge result sets)
- Allowlist `sortBy` to known field names (`createdAt`, `totalPrice`, `totalWeightKg` for orders; `createdAt`, `name`, `email` for users) — prevents internal Prisma field probing via error messages
- Selective field queries on order detail and pickup requests: only `id`, `name`, `email`, `phone` returned for `customerUser` and `staff.user` (no password hashes or tokens exposed)
- Wrap staff + user deletion in `prisma.$transaction` — atomic operation prevents orphaned records if one delete fails
- `updateAdminUser` now returns a full `AdminUserResponse` via `toAdminUserResponse` mapper
- Add `GET /api/v1/admin/laundry-items` endpoint returning id, name, slug for all laundry items

## Why
Pagination without an upper bound allows a single request to return all rows. Sort field pass-through to Prisma exposes internal schema details via error messages. Non-atomic deletion could leave orphaned `User` records if `Staff` delete succeeds but `User` delete fails.

## How to test
- [ ] `npm test -- tests/unit/admin-user-service.test.ts` — $transaction mock and deletion tests pass
- [ ] `npm run build` — compiles without errors
- [ ] `GET /api/v1/admin/orders?limit=9999` — returns at most 100 records
- [ ] `GET /api/v1/admin/orders?sortBy=invalidField` — falls back to `createdAt`, no 500 error
- [ ] `GET /api/v1/admin/orders/:id` — `customerUser` contains only `id`, `name`, `email`, `phone`; no password field
- [ ] `GET /api/v1/admin/laundry-items` — returns array of `{ id, name, slug }` items
- [ ] Delete a staff user: both `Staff` and `User` records removed atomically