### PR TITLE
feat: add admin dashboard stats endpoint

### DIFF
--- a/src/features/users/user-controller.ts
+++ b/src/features/users/user-controller.ts
@@ -43,4 +43,14 @@ export class UserController {
       next(error);
     }
   }
+
+  static async getDashboardStats(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const outletId = req.staff?.outletId ?? null;
+      const result = await UserService.getDashboardStats(outletId);
+      res.status(200).json({ status: 'success', message: 'Dashboard stats retrieved', data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/features/users/user-model.ts
+++ b/src/features/users/user-model.ts
@@ -39,3 +39,17 @@ export function toUserResponse(user: User): CustomerRegistrationResponse {
     emailVerified: user.emailVerified,
   };
 }
+
+export type DashboardStatsResponse = {
+  totalOrders: number;
+  activeOutlets: number;
+  registeredUsers: number;
+  revenueMtd: number;
+  recentOrders: {
+    id: string;
+    customerName: string;
+    status: string;
+    outletName: string;
+    createdAt: Date;
+  }[];
+};

--- a/src/features/users/user-service.ts
+++ b/src/features/users/user-service.ts
@@ -3,7 +3,7 @@ import { ResponseError } from '@/error/response-error';
 import { sendEmail } from '@/utils/mailer';
 import bcrypt from 'bcrypt';
 import { v4 as uuid } from 'uuid';
-import { RegisterInput, ResendVerificationInput, SetPasswordInput, toUserResponse } from './user-model';
+import { DashboardStatsResponse, RegisterInput, ResendVerificationInput, SetPasswordInput, toUserResponse } from './user-model';
 
 // Clears any existing tokens for this email before issuing a new one, preventing stale links.
 const createVerificationToken = async (email: string): Promise<string> => {
@@ -81,6 +81,48 @@ export class UserService {
     const token = await createVerificationToken(data.email);
     sendSetPasswordEmail(data.email, token);
     return { message: 'Verification email sent' };
+  }
+
+  static async getDashboardStats(outletId: string | null): Promise<DashboardStatsResponse> {
+    const outletFilter = outletId ? { outletId } : {};
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const [totalOrders, activeOutlets, registeredUsers, revenueResult, recentOrders] = await prisma.$transaction([
+      prisma.order.count({ where: outletFilter }),
+      prisma.outlet.count({ where: { isActive: true } }),
+      prisma.user.count({ where: { staff: null } }),
+      prisma.order.aggregate({
+        _sum: { totalPrice: true },
+        where: { ...outletFilter, paymentStatus: 'PAID', createdAt: { gte: startOfMonth } },
+      }),
+      prisma.order.findMany({
+        where: outletFilter,
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          status: true,
+          createdAt: true,
+          outlet: { select: { name: true } },
+          pickupRequest: { select: { customerUser: { select: { name: true } } } },
+        },
+      }),
+    ]);
+
+    return {
+      totalOrders,
+      activeOutlets,
+      registeredUsers,
+      revenueMtd: revenueResult._sum.totalPrice ?? 0,
+      recentOrders: recentOrders.map((o) => ({
+        id: o.id,
+        customerName: o.pickupRequest.customerUser.name ?? 'Unknown',
+        status: o.status,
+        outletName: o.outlet.name,
+        createdAt: o.createdAt,
+      })),
+    };
   }
 
   static async getMe(userId: string) {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -8,6 +8,7 @@ export const apiRouter = express.Router();
 
 apiRouter.get('/users/me', requireAuth, UserController.getMe);
 
+apiRouter.get('/admin/dashboard', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), UserController.getDashboardStats);
 apiRouter.get('/admin/users', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminUserController.getAdminUsers);
 apiRouter.get('/admin/orders', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getAdminOrders);
 apiRouter.get('/admin/orders/:id', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getAdminOrderDetail);


### PR DESCRIPTION
## What changed
- Add `GET /api/v1/admin/dashboard` endpoint (requires `SUPER_ADMIN` or `OUTLET_ADMIN`)
- Returns: total orders, active outlets, registered customers, revenue month-to-date, and 5 most recent orders
- `OUTLET_ADMIN` results are scoped to their outlet; `SUPER_ADMIN` sees platform-wide stats
- All 5 aggregates fetched in a single `$transaction` for consistency

## Why
Admins need a quick overview of key platform metrics without querying multiple endpoints. MTD revenue and recent orders give immediate operational visibility.

## How to test
- [ ] `npm run build` — compiles without errors
- [ ] Authenticated as `SUPER_ADMIN`: `GET /api/v1/admin/dashboard` returns `{ totalOrders, activeOutlets, registeredUsers, revenueMtd, recentOrders }`
- [ ] Authenticated as `OUTLET_ADMIN`: same endpoint returns stats scoped to their outlet only
- [ ] Authenticated as `WORKER` or unauthenticated: returns 403 / 401
- [ ] `recentOrders` array contains at most 5 entries, ordered by `createdAt` descending