### PR TITLE
feat: add customer order tracking and receipt confirmation endpoints

### DIFF
--- a/src/features/orders/order-controller.ts
+++ b/src/features/orders/order-controller.ts
@@ -1,0 +1,46 @@
+import { NextFunction, Response } from 'express';
+import { UserRequest } from '@/types/user-request';
+import { Validation } from '@/validations/validation';
+import { CustomerOrderListQuerySchema } from './order-model';
+import { OrderService } from './order-service';
+
+export class OrderController {
+
+  static async listOrders(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(CustomerOrderListQuerySchema, req.query);
+      const result = await OrderService.listOrders(req.user!.id, query);
+      res.status(200).json({
+        status: 'success',
+        message: 'Orders retrieved',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getOrderDetail(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const orderId = req.params.id as string;
+      const result = await OrderService.getOrderDetail(req.user!.id, orderId);
+      res.status(200).json({
+        status: 'success',
+        message: 'Order retrieved',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async confirmReceipt(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const result = await OrderService.confirmReceipt(req.user!.id, req.params.id as string);
+      res.status(200).json({ status: 'success', message: 'Order confirmed', data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/orders/order-model.ts
+++ b/src/features/orders/order-model.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { OrderStatus } from '@/generated/prisma/enums';
+
+export const CustomerOrderListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  status: z.nativeEnum(OrderStatus).optional(),
+});
+
+export type CustomerOrderListQuery = z.infer<typeof CustomerOrderListQuerySchema>;

--- a/src/features/orders/order-service.ts
+++ b/src/features/orders/order-service.ts
@@ -1,0 +1,81 @@
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import { OrderStatus } from '@/generated/prisma/enums';
+import { CustomerOrderListQuery } from './order-model';
+
+export class OrderService {
+
+  static async listOrders(userId: string, query: CustomerOrderListQuery) {
+    const skip = (query.page - 1) * query.limit;
+    const where = {
+      pickupRequest: { customerId: userId },
+      ...(query.status ? { status: query.status } : {}),
+    };
+
+    const [orders, total] = await Promise.all([
+      prisma.order.findMany({
+        where,
+        skip,
+        take: query.limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          outlet: { select: { id: true, name: true } },
+          items: { include: { laundryItem: { select: { id: true, name: true, slug: true } } } },
+        },
+      }),
+      prisma.order.count({ where }),
+    ]);
+
+    return {
+      data: orders,
+      meta: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    };
+  }
+
+  static async getOrderDetail(userId: string, orderId: string) {
+    const order = await prisma.order.findUnique({
+      where: { id: orderId },
+      include: {
+        outlet: { select: { id: true, name: true } },
+        items: { include: { laundryItem: { select: { id: true, name: true, slug: true } } } },
+        stationRecords: {
+          include: {
+            staff: { include: { user: { select: { id: true, name: true } } } },
+            stationItems: true,
+            bypassRequests: { select: { id: true, status: true } },
+          },
+        },
+        pickupRequest: { include: { address: true } },
+      },
+    });
+
+    if (!order || order.pickupRequest.customerId !== userId) {
+      throw new ResponseError(404, 'Order not found');
+    }
+
+    return order;
+  }
+
+  static async confirmReceipt(userId: string, orderId: string) {
+    return prisma.$transaction(async (tx) => {
+      const order = await tx.order.findUnique({
+        where: { id: orderId },
+        include: { pickupRequest: true },
+      });
+      if (!order) throw new ResponseError(404, 'Order not found');
+      if (order.pickupRequest.customerId !== userId) throw new ResponseError(403, 'Forbidden');
+      if (order.status !== 'LAUNDRY_DELIVERED_TO_CUSTOMER') {
+        throw new ResponseError(400, 'Order cannot be confirmed at this stage');
+      }
+      return tx.order.update({
+        where: { id: orderId },
+        data: { status: 'COMPLETED', confirmedAt: new Date() },
+      });
+    });
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -3,6 +3,8 @@ import { requireAuth, requireStaffRole } from '@/middleware/auth-middleware';
 import { UserController } from '@/features/users/user-controller';
 import { AdminUserController } from '@/features/admin-users/admin-user-controller';
 import { AdminOrderController } from '@/features/admin-orders/admin-order-controller';
+import { OrderController } from '@/features/orders/order-controller';
+import { requireCustomerAuth } from '@/middleware/auth-middleware';
 
 export const apiRouter = express.Router();
 
@@ -18,3 +20,7 @@ apiRouter.post('/admin/users', requireStaffRole('SUPER_ADMIN'), AdminUserControl
 apiRouter.patch('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.updateAdminUser);
 apiRouter.get('/admin/laundry-items', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getLaundryItems);
 apiRouter.delete('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.deleteAdminUser);
+
+apiRouter.get('/orders', requireCustomerAuth, OrderController.listOrders);
+apiRouter.get('/orders/:id', requireCustomerAuth, OrderController.getOrderDetail);
+apiRouter.post('/orders/:id/confirm', requireCustomerAuth, OrderController.confirmReceipt);


### PR DESCRIPTION
## What changed
- Add `GET /api/v1/orders` — paginated list of the authenticated customer's orders
- Add `GET /api/v1/orders/:id` — full order detail including items, station records, and current status
- Add `POST /api/v1/orders/:id/confirm` — customer confirms receipt, advancing order to `COMPLETED`
- All three routes require `requireCustomerAuth` (staff members cannot call customer order endpoints)

## Why
Customers need visibility into their active and past orders, and must be able to confirm delivery to complete the order lifecycle (triggering the 2×24h auto-confirm window reset).

## How to test
- [ ] `npm run build` — compiles without errors
- [ ] Authenticated as customer: `GET /api/v1/orders` returns paginated list of that customer's orders only
- [ ] `GET /api/v1/orders/:id` with another customer's order ID — returns 403 or 404
- [ ] After order reaches `LAUNDRY_DELIVERED_TO_CUSTOMER`: `POST /api/v1/orders/:id/confirm` sets status to `COMPLETED`
- [ ] Authenticated as staff: all three routes return 403