### PR TITLE
get bypass requests

### DIFF
--- a/docs/bypass-requests.md
+++ b/docs/bypass-requests.md
@@ -49,7 +49,8 @@ List bypass requests for the outlet admin's outlet. Pending requests should be p
   "meta": {
     "page": 1,
     "limit": 10,
-    "total": 3
+    "total": 3,
+    "totalPages": 1
   }
 }
 ```

--- a/src/features/bypass-requests/bypass-request-controller.ts
+++ b/src/features/bypass-requests/bypass-request-controller.ts
@@ -42,7 +42,6 @@ export class BypassRequestController {
       const page = Number(req.query.page) || 1;
       const limit = Number(req.query.limit) || 10;
 
-      // Validate status parameter if provided
       let status: BypassStatus | undefined;
       if (req.query.status) {
         status = Validation.validate(
@@ -51,16 +50,20 @@ export class BypassRequestController {
         );
       }
 
+      const rawOrder = req.query.order;
+      const order: 'asc' | 'desc' =
+        rawOrder === 'asc' || rawOrder === 'desc' ? rawOrder : 'desc';
+
       const result = await BypassRequestService.getAll(
         req.staff!.id,
         req.staff!.role,
         req.staff!.outletId ?? undefined,
-        { page, limit, status }
+        { page, limit, status, order }
       );
 
       res.status(200).json({
         status: 'success',
-        message: 'Bypass requests fetched',
+        message: 'Bypass requests retrieved',
         data: result.data,
         meta: result.meta,
       });

--- a/src/features/bypass-requests/bypass-request-controller.ts
+++ b/src/features/bypass-requests/bypass-request-controller.ts
@@ -4,6 +4,7 @@ import { Validation } from '@/validations/validation';
 import { BypassRequestValidation } from '@/validations/bypass-request-validation';
 import { UserRequest } from '@/types/user-request';
 import type { StationType } from '@/generated/prisma/client';
+import { BypassStatus } from './bypass-request-model';
 
 export class BypassRequestController {
   static async create(req: UserRequest, res: Response, next: NextFunction) {
@@ -29,6 +30,39 @@ export class BypassRequestController {
         status: 'success',
         message: 'Bypass request submitted. Awaiting admin approval.',
         data: result,
+      });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  // PCS-128: Get bypass requests for admin review
+  static async getAll(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const page = Number(req.query.page) || 1;
+      const limit = Number(req.query.limit) || 10;
+
+      // Validate status parameter if provided
+      let status: BypassStatus | undefined;
+      if (req.query.status) {
+        status = Validation.validate(
+          BypassRequestValidation.STATUS_ENUM,
+          req.query.status
+        );
+      }
+
+      const result = await BypassRequestService.getAll(
+        req.staff!.id,
+        req.staff!.role,
+        req.staff!.outletId ?? undefined,
+        { page, limit, status }
+      );
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Bypass requests fetched',
+        data: result.data,
+        meta: result.meta,
       });
     } catch (e) {
       next(e);

--- a/src/features/bypass-requests/bypass-request-controller.ts
+++ b/src/features/bypass-requests/bypass-request-controller.ts
@@ -3,12 +3,17 @@ import { BypassRequestService } from './bypass-request-service';
 import { Validation } from '@/validations/validation';
 import { BypassRequestValidation } from '@/validations/bypass-request-validation';
 import { UserRequest } from '@/types/user-request';
+import { ResponseError } from '@/error/response-error';
 import type { StationType } from '@/generated/prisma/client';
 import { BypassStatus } from './bypass-request-model';
 
 export class BypassRequestController {
   static async create(req: UserRequest, res: Response, next: NextFunction) {
     try {
+      if (!req.staff) {
+        throw new ResponseError(401, 'Authentication required');
+      }
+
       const station = Validation.validate(
         BypassRequestValidation.STATION_PARAM,
         req.params.station
@@ -20,7 +25,7 @@ export class BypassRequestController {
       );
 
       const result = await BypassRequestService.create(
-        req.staff!.id,
+        req.staff.id,
         Array.isArray(req.params.id) ? req.params.id[0] : req.params.id,
         station,
         request
@@ -39,8 +44,14 @@ export class BypassRequestController {
   // PCS-128: Get bypass requests for admin review
   static async getAll(req: UserRequest, res: Response, next: NextFunction) {
     try {
-      const page = Number(req.query.page) || 1;
-      const limit = Number(req.query.limit) || 10;
+      if (!req.staff) {
+        throw new ResponseError(401, 'Authentication required');
+      }
+
+      const rawPage = Number(req.query.page);
+      const rawLimit = Number(req.query.limit);
+      const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+      const limit = Number.isInteger(rawLimit) && rawLimit > 0 ? rawLimit : 10;
 
       let status: BypassStatus | undefined;
       if (req.query.status) {
@@ -50,14 +61,15 @@ export class BypassRequestController {
         );
       }
 
-      const rawOrder = req.query.order;
-      const order: 'asc' | 'desc' =
-        rawOrder === 'asc' || rawOrder === 'desc' ? rawOrder : 'desc';
+      let order: 'asc' | 'desc' = 'desc';
+      if (req.query.order) {
+        order = Validation.validate(BypassRequestValidation.ORDER, req.query.order);
+      }
 
       const result = await BypassRequestService.getAll(
-        req.staff!.id,
-        req.staff!.role,
-        req.staff!.outletId ?? undefined,
+        req.staff.id,
+        req.staff.role,
+        req.staff.outletId ?? undefined,
         { page, limit, status, order }
       );
 

--- a/src/features/bypass-requests/bypass-request-model.ts
+++ b/src/features/bypass-requests/bypass-request-model.ts
@@ -68,8 +68,8 @@ export function toBypassResponse(
 ): BypassRequestResponse {
   return {
     id: bypass.id,
-    orderId: bypass.stationRecord.order.id,
-    station: bypass.stationRecord.station,
+    orderId: bypass.stationRecord?.order?.id ?? '',
+    station: bypass.stationRecord?.station ?? '',
     workerName: bypass.worker?.user?.name ?? 'Unknown',
     status: bypass.status as BypassStatus,
     createdAt: bypass.createdAt,

--- a/src/features/bypass-requests/bypass-request-model.ts
+++ b/src/features/bypass-requests/bypass-request-model.ts
@@ -22,7 +22,7 @@ export type BypassRequestResponse = {
   workerName: string;
   status: BypassStatus;
   createdAt: Date;
-  resolvedAt?: Date | null;
+  resolvedAt: Date | null;
 };
 
 // For CREATE response (minimal)
@@ -73,6 +73,6 @@ export function toBypassResponse(
     workerName: bypass.worker?.user?.name ?? 'Unknown',
     status: bypass.status as BypassStatus,
     createdAt: bypass.createdAt,
-    resolvedAt: bypass.resolvedAt ?? undefined,
+    resolvedAt: bypass.resolvedAt,
   };
 }

--- a/src/features/bypass-requests/bypass-request-model.ts
+++ b/src/features/bypass-requests/bypass-request-model.ts
@@ -1,4 +1,4 @@
-import type { BypassRequest } from '@/generated/prisma/client';
+import type { BypassRequest, Prisma } from '@/generated/prisma/client';
 
 export type BypassItemInput = {
   laundryItemId: string;
@@ -9,20 +9,70 @@ export type CreateBypassRequestInput = {
   items: BypassItemInput[];
 };
 
+export enum BypassStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}
+
 export type BypassRequestResponse = {
-  bypassRequestId: string;
-  stationRecordId: string;
-  status: string;
+  id: string;
+  orderId: string;
+  station: string;
+  workerName: string;
+  status: BypassStatus;
+  createdAt: Date;
+  resolvedAt?: Date | null;
+};
+
+// For CREATE response (minimal)
+export type BypassRequestCreateResponse = {
+  id: string;
+  status: BypassStatus;
   createdAt: Date;
 };
 
-export function toBypassResponse(
+// For service responses
+type BypassWithRelations = Prisma.BypassRequestGetPayload<{
+  include: {
+    stationRecord: {
+      include: {
+        order: true;
+      };
+    };
+    worker: {
+      include: {
+        user: true;
+      };
+    };
+    admin: {
+      include: {
+        user: true;
+      };
+    };
+  };
+}>;
+
+export function toBypassCreateResponse(
   bypass: BypassRequest
+): BypassRequestCreateResponse {
+  return {
+    id: bypass.id,
+    status: bypass.status as BypassStatus,
+    createdAt: bypass.createdAt,
+  };
+}
+
+export function toBypassResponse(
+  bypass: BypassWithRelations
 ): BypassRequestResponse {
   return {
-    bypassRequestId: bypass.id,
-    stationRecordId: bypass.stationRecordId,
-    status: bypass.status,
+    id: bypass.id,
+    orderId: bypass.stationRecord.order.id,
+    station: bypass.stationRecord.station,
+    workerName: bypass.worker?.user?.name ?? 'Unknown',
+    status: bypass.status as BypassStatus,
     createdAt: bypass.createdAt,
+    resolvedAt: bypass.resolvedAt ?? undefined,
   };
 }

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -145,9 +145,9 @@ export class BypassRequestService {
     adminId: string,
     role: string,
     outletId: string | undefined,
-    options: { page: number; limit: number; status?: BypassStatus }
+    options: { page: number; limit: number; status?: BypassStatus; order?: 'asc' | 'desc' }
   ) {
-    const { page, limit, status } = options;
+    const { page, limit, status, order = 'desc' } = options;
     const skip = (page - 1) * limit;
 
     const where: Prisma.BypassRequestWhereInput = {};
@@ -186,7 +186,7 @@ export class BypassRequestService {
             },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { createdAt: order },
         skip,
         take: limit,
       }),

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -199,6 +199,7 @@ export class BypassRequestService {
         page,
         limit,
         total,
+        totalPages: Math.ceil(total / limit),
       },
     };
   }

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/application/database';
 import { ResponseError } from '@/error/response-error';
-import { CreateBypassRequestInput, toBypassResponse } from './bypass-request-model';
-import type { StationType } from '@/generated/prisma/client';
+import { CreateBypassRequestInput, toBypassResponse, toBypassCreateResponse, BypassStatus } from './bypass-request-model';
+import type { StationType, Prisma } from '@/generated/prisma/client';
 
 export class BypassRequestService {
   static async create(
@@ -136,7 +136,70 @@ export class BypassRequestService {
         },
       });
 
-      return toBypassResponse(bypass);
+      return toBypassCreateResponse(bypass);
     });
+  }
+
+  // PCS-128: Get bypass requests for admin
+  static async getAll(
+    adminId: string,
+    role: string,
+    outletId: string | undefined,
+    options: { page: number; limit: number; status?: BypassStatus }
+  ) {
+    const { page, limit, status } = options;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.BypassRequestWhereInput = {};
+
+    // Filter by status if provided
+    if (status) {
+      where.status = status;
+    }
+
+    // Filter by outlet if OUTLET_ADMIN
+    if (role === 'OUTLET_ADMIN' && outletId) {
+      where.stationRecord = {
+        order: {
+          outletId,
+        },
+      };
+    }
+
+    const [data, total] = await Promise.all([
+      prisma.bypassRequest.findMany({
+        where,
+        include: {
+          stationRecord: {
+            include: {
+              order: true,
+            },
+          },
+          worker: {
+            include: {
+              user: true,
+            },
+          },
+          admin: {
+            include: {
+              user: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      prisma.bypassRequest.count({ where }),
+    ]);
+
+    return {
+      data: data.map(toBypassResponse),
+      meta: {
+        page,
+        limit,
+        total,
+      },
+    };
   }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -45,6 +45,13 @@ apiRouter.post(
   BypassRequestController.create
 );
 
+// BYPASS REQUEST (PCS-128)
+apiRouter.get(
+  '/bypass-requests',
+  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
+  BypassRequestController.getAll
+);
+
 // ORDER
 apiRouter.get('/orders', requireCustomerAuth, OrderController.listOrders);
 apiRouter.get('/orders/:id', requireCustomerAuth, OrderController.getOrderDetail);

--- a/src/validations/bypass-request-validation.ts
+++ b/src/validations/bypass-request-validation.ts
@@ -1,5 +1,6 @@
 import { z, ZodType } from 'zod';
 import type { CreateBypassRequestInput } from '@/features/bypass-requests/bypass-request-model';
+import { BypassStatus } from '@/features/bypass-requests/bypass-request-model';
 
 export class BypassRequestValidation {
   static readonly CREATE: ZodType<CreateBypassRequestInput> = z.object({
@@ -12,4 +13,10 @@ export class BypassRequestValidation {
   });
 
   static readonly STATION_PARAM: ZodType<string> = z.enum(['WASHING', 'IRONING', 'PACKING']);
+
+  static readonly STATUS_ENUM: ZodType<BypassStatus> = z.enum([
+    BypassStatus.PENDING,
+    BypassStatus.APPROVED,
+    BypassStatus.REJECTED,
+  ] as const) as ZodType<BypassStatus>;
 }

--- a/src/validations/bypass-request-validation.ts
+++ b/src/validations/bypass-request-validation.ts
@@ -19,4 +19,8 @@ export class BypassRequestValidation {
     BypassStatus.APPROVED,
     BypassStatus.REJECTED,
   ] as const) as ZodType<BypassStatus>;
+
+  static readonly SORT_BY: ZodType<string> = z.enum(['createdAt']);
+
+  static readonly ORDER: ZodType<'asc' | 'desc'> = z.enum(['asc', 'desc']);
 }

--- a/src/validations/bypass-request-validation.ts
+++ b/src/validations/bypass-request-validation.ts
@@ -20,7 +20,5 @@ export class BypassRequestValidation {
     BypassStatus.REJECTED,
   ] as const) as ZodType<BypassStatus>;
 
-  static readonly SORT_BY: ZodType<string> = z.enum(['createdAt']);
-
   static readonly ORDER: ZodType<'asc' | 'desc'> = z.enum(['asc', 'desc']);
 }

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -10,7 +10,7 @@ jest.mock('@/application/database', () => ({
     stationRecord: { findUnique: jest.fn(), update: jest.fn() },
     orderItem: { findMany: jest.fn() },
     stationItem: { deleteMany: jest.fn(), create: jest.fn() },
-    bypassRequest: { findFirst: jest.fn(), create: jest.fn() },
+    bypassRequest: { findFirst: jest.fn(), create: jest.fn(), findMany: jest.fn(), count: jest.fn() },
     $transaction: jest.fn(),
   },
 }));
@@ -45,6 +45,23 @@ describe('Bypass Routes Integration Tests', () => {
   const mockAuthenticatedWorker = (userId: string = 'user-1', staffId: string = 'staff-1') => {
     const mockUser = { id: userId, email: 'worker@example.com' };
     const mockStaff = { id: staffId, role: 'WORKER', isActive: true };
+
+    (auth.api.getSession as jest.Mock).mockResolvedValue({
+      user: mockUser,
+      session: 'token',
+    });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  const mockAuthenticatedAdmin = (
+    userId = 'user-admin',
+    staffId = 'staff-admin',
+    outletId: string | null = 'outlet-1'
+  ) => {
+    const mockUser = { id: userId, email: 'admin@example.com' };
+    const mockStaff = { id: staffId, role: 'OUTLET_ADMIN', isActive: true, outletId };
 
     (auth.api.getSession as jest.Mock).mockResolvedValue({
       user: mockUser,
@@ -208,6 +225,76 @@ describe('Bypass Routes Integration Tests', () => {
         .send({
           items: [{ laundryItemId: VALID_UUID, quantity: 3 }],
         });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/v1/bypass-requests', () => {
+    const makeBypassRecord = () => ({
+      id: 'bp-1',
+      stationRecord: {
+        station: 'IRONING',
+        order: { id: 'ord-1', outletId: 'outlet-1' },
+      },
+      worker: { user: { name: 'Bob Ironing' } },
+      admin: null,
+      status: 'PENDING',
+      createdAt: new Date('2026-03-07T11:00:00.000Z'),
+      resolvedAt: null,
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(app).get('/api/v1/bypass-requests');
+
+      expect(response.status).toBe(401);
+    });
+
+    it('returns 403 for WORKER role', async () => {
+      mockAuthenticatedWorker();
+
+      const response = await request(app).get('/api/v1/bypass-requests');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('returns 200 with paginated envelope for OUTLET_ADMIN', async () => {
+      mockAuthenticatedAdmin();
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypassRecord()]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      const response = await request(app).get('/api/v1/bypass-requests');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.message).toBe('Bypass requests retrieved');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.meta).toMatchObject({ page: 1, limit: 10, total: 1 });
+    });
+
+    it('filters correctly when ?status=PENDING is provided', async () => {
+      mockAuthenticatedAdmin();
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypassRecord()]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      const response = await request(app)
+        .get('/api/v1/bypass-requests')
+        .query({ status: 'PENDING' });
+
+      expect(response.status).toBe(200);
+      expect(
+        (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0].where
+      ).toMatchObject({ status: 'PENDING' });
+    });
+
+    it('returns 400 for invalid status value', async () => {
+      mockAuthenticatedAdmin();
+
+      const response = await request(app)
+        .get('/api/v1/bypass-requests')
+        .query({ status: 'INVALID_STATUS' });
 
       expect(response.status).toBe(400);
     });

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -271,7 +271,7 @@ describe('Bypass Routes Integration Tests', () => {
       expect(response.body.status).toBe('success');
       expect(response.body.message).toBe('Bypass requests retrieved');
       expect(Array.isArray(response.body.data)).toBe(true);
-      expect(response.body.meta).toMatchObject({ page: 1, limit: 10, total: 1 });
+      expect(response.body.meta).toMatchObject({ page: 1, limit: 10, total: 1, totalPages: 1 });
     });
 
     it('filters correctly when ?status=PENDING is provided', async () => {
@@ -297,6 +297,32 @@ describe('Bypass Routes Integration Tests', () => {
         .query({ status: 'INVALID_STATUS' });
 
       expect(response.status).toBe(400);
+    });
+
+    it('returns 400 for invalid order value', async () => {
+      mockAuthenticatedAdmin();
+
+      const response = await request(app)
+        .get('/api/v1/bypass-requests')
+        .query({ order: 'INVALID_ORDER' });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 200 for SUPER_ADMIN role', async () => {
+      const mockUser = { id: 'user-super', email: 'super@example.com' };
+      const mockStaff = { id: 'staff-super', role: 'SUPER_ADMIN', isActive: true, outletId: null };
+
+      (auth.api.getSession as jest.Mock).mockResolvedValue({ user: mockUser, session: 'token' });
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypassRecord()]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      const response = await request(app).get('/api/v1/bypass-requests');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
     });
   });
 });

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -177,8 +177,7 @@ describe('Bypass Routes Integration Tests', () => {
         status: 'success',
         message: 'Bypass request submitted. Awaiting admin approval.',
         data: {
-          bypassRequestId: bypassId,
-          stationRecordId,
+          id: bypassId,
           status: 'PENDING',
           createdAt: now.toISOString(),
         },

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -16,15 +16,27 @@ const mockTx = {
   },
 };
 
+const mockPrisma = {
+  bypassRequest: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+};
+
 jest.mock('@/application/database', () => ({
   prisma: {
     $transaction: jest.fn((callback: (tx: typeof mockTx) => Promise<any>) => callback(mockTx)),
+    bypassRequest: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
   },
 }));
 
 import { BypassRequestService } from '@/features/bypass-requests/bypass-request-service';
 import { prisma } from '@/application/database';
 import { ResponseError } from '@/error/response-error';
+import { BypassStatus } from '@/features/bypass-requests/bypass-request-model';
 
 describe('BypassRequestService', () => {
   beforeEach(() => {
@@ -32,6 +44,8 @@ describe('BypassRequestService', () => {
     (prisma.$transaction as jest.Mock).mockImplementation(
       (callback: (tx: typeof mockTx) => Promise<any>) => callback(mockTx)
     );
+    (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(0);
   });
 
   describe('create', () => {
@@ -238,6 +252,113 @@ describe('BypassRequestService', () => {
         },
         include: { stationItems: true },
       });
+    });
+  });
+
+  describe('getAll', () => {
+    const makeBypass = (overrides = {}) => ({
+      id: 'bp-1',
+      stationRecord: {
+        station: 'IRONING',
+        order: { id: 'ord-1', outletId: 'outlet-1' },
+      },
+      worker: { user: { name: 'Bob Ironing' } },
+      admin: null,
+      status: 'PENDING',
+      createdAt: new Date('2026-03-07T11:00:00.000Z'),
+      resolvedAt: null,
+      ...overrides,
+    });
+
+    it('SUPER_ADMIN: does not add outlet filter to where clause', async () => {
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypass()]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      await BypassRequestService.getAll('admin-1', 'SUPER_ADMIN', undefined, {
+        page: 1,
+        limit: 10,
+      });
+
+      const findManyCall = (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0];
+      expect(findManyCall.where).not.toHaveProperty('stationRecord');
+    });
+
+    it('OUTLET_ADMIN with outletId: adds stationRecord.order.outletId filter', async () => {
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypass()]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      await BypassRequestService.getAll('admin-1', 'OUTLET_ADMIN', 'outlet-1', {
+        page: 1,
+        limit: 10,
+      });
+
+      const findManyCall = (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0];
+      expect(findManyCall.where).toMatchObject({
+        stationRecord: { order: { outletId: 'outlet-1' } },
+      });
+    });
+
+    it('applies status filter when provided', async () => {
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(0);
+
+      await BypassRequestService.getAll('admin-1', 'SUPER_ADMIN', undefined, {
+        page: 1,
+        limit: 10,
+        status: BypassStatus.PENDING,
+      });
+
+      const findManyCall = (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0];
+      expect(findManyCall.where).toMatchObject({ status: 'PENDING' });
+    });
+
+    it('returns correct data and meta shape', async () => {
+      const bypass = makeBypass();
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([bypass]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+
+      const result = await BypassRequestService.getAll('admin-1', 'SUPER_ADMIN', undefined, {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.meta).toEqual({ page: 1, limit: 10, total: 1 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: 'bp-1',
+        orderId: 'ord-1',
+        station: 'IRONING',
+        workerName: 'Bob Ironing',
+        status: 'PENDING',
+        resolvedAt: null,
+      });
+    });
+
+    it('orderBy respects the order param (asc)', async () => {
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(0);
+
+      await BypassRequestService.getAll('admin-1', 'SUPER_ADMIN', undefined, {
+        page: 1,
+        limit: 10,
+        order: 'asc',
+      });
+
+      const findManyCall = (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0];
+      expect(findManyCall.orderBy).toEqual({ createdAt: 'asc' });
+    });
+
+    it('orderBy defaults to desc when order param is omitted', async () => {
+      (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(0);
+
+      await BypassRequestService.getAll('admin-1', 'SUPER_ADMIN', undefined, {
+        page: 1,
+        limit: 10,
+      });
+
+      const findManyCall = (prisma.bypassRequest.findMany as jest.Mock).mock.calls[0][0];
+      expect(findManyCall.orderBy).toEqual({ createdAt: 'desc' });
     });
   });
 });

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -16,13 +16,6 @@ const mockTx = {
   },
 };
 
-const mockPrisma = {
-  bypassRequest: {
-    findMany: jest.fn(),
-    count: jest.fn(),
-  },
-};
-
 jest.mock('@/application/database', () => ({
   prisma: {
     $transaction: jest.fn((callback: (tx: typeof mockTx) => Promise<any>) => callback(mockTx)),
@@ -253,6 +246,71 @@ describe('BypassRequestService', () => {
         include: { stationItems: true },
       });
     });
+
+    it('uses correct reference source for PACKING station', async () => {
+      mockTx.stationRecord.findUnique
+        .mockResolvedValueOnce({
+          id: stationRecordId,
+          orderId,
+          station: 'PACKING',
+          staffId: workerId,
+          status: 'IN_PROGRESS',
+          stationItems: [],
+        })
+        .mockResolvedValueOnce({
+          id: 'sr-ironing',
+          orderId,
+          station: 'IRONING',
+          stationItems: [{ laundryItemId: 'item-1', quantity: 5 }],
+        });
+
+      mockTx.bypassRequest.findFirst.mockResolvedValue(null);
+      mockTx.stationItem.deleteMany.mockResolvedValue({ count: 0 });
+      mockTx.stationItem.create.mockResolvedValue({});
+      mockTx.bypassRequest.create.mockResolvedValue({
+        id: 'bp-1',
+        stationRecordId,
+        workerId,
+        adminId: null,
+        problemDescription: null,
+        status: 'PENDING',
+        createdAt: new Date(),
+      });
+      mockTx.stationRecord.update.mockResolvedValue({});
+
+      await BypassRequestService.create(workerId, orderId, 'PACKING', {
+        items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
+      });
+
+      expect(mockTx.stationRecord.findUnique).toHaveBeenCalledTimes(2);
+      expect(mockTx.stationRecord.findUnique).toHaveBeenNthCalledWith(2, {
+        where: {
+          orderId_station: { orderId, station: 'IRONING' },
+        },
+        include: { stationItems: true },
+      });
+    });
+
+    it('throws 422 when previous station record not found', async () => {
+      mockTx.stationRecord.findUnique
+        .mockResolvedValueOnce({
+          id: stationRecordId,
+          orderId,
+          station: 'IRONING',
+          staffId: workerId,
+          status: 'IN_PROGRESS',
+          stationItems: [],
+        })
+        .mockResolvedValueOnce(null); // prev station missing
+
+      await expect(
+        BypassRequestService.create(workerId, orderId, 'IRONING', {
+          items: [{ laundryItemId: 'item-1', quantity: 3 }],
+        })
+      ).rejects.toThrow(
+        new ResponseError(422, 'Previous station has no completed records. Cannot proceed.')
+      );
+    });
   });
 
   describe('getAll', () => {
@@ -322,7 +380,7 @@ describe('BypassRequestService', () => {
         limit: 10,
       });
 
-      expect(result.meta).toEqual({ page: 1, limit: 10, total: 1 });
+      expect(result.meta).toEqual({ page: 1, limit: 10, total: 1, totalPages: 1 });
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toMatchObject({
         id: 'bp-1',

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -189,8 +189,7 @@ describe('BypassRequestService', () => {
       });
 
       expect(result).toEqual({
-        bypassRequestId: 'bp-1',
-        stationRecordId,
+        id: 'bp-1',
         status: 'PENDING',
         createdAt: createdBypass.createdAt,
       });


### PR DESCRIPTION
## Summary
Implement endpoint to get pending bypass requests for admin.

## Features
- Get all pending bypass requests
- Filter by role:
  - SUPER_ADMIN → all data
  - OUTLET_ADMIN → only own outlet
- Include related data:
  - stationRecord
  - order
  - worker
  - admin
- Sorted by latest

## Testing Steps
1. Login as admin
2. Open browser:
   http://localhost:2000/api/v1/admin/bypass-requests
3. Ensure response returns list of bypass requests

## Result
Endpoint successfully returns data from database

## Jira
PCS-128