### PR TITLE
PCS-133: add worker order queue endpoint

### DIFF
--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Response } from 'express';
+import { Validation } from '@/validations/validation';
+import { WorkerOrderValidation } from '@/validations/worker-order-validation';
+import { UserRequest } from '@/types/user-request';
+import { WorkerOrderService } from './worker-order-service';
+
+export class WorkerOrderController {
+  static async getOrders(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(WorkerOrderValidation.LIST, req.query);
+      const result = await WorkerOrderService.getWorkerOrders(req.staff!, query);
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker orders retrieved',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -1,0 +1,61 @@
+import type { Prisma, Staff, StationStatus, StationType } from '@/generated/prisma/client';
+
+export type WorkerOrderListQuery = {
+  page: number;
+  limit: number;
+  status?: StationStatus;
+  date?: string;
+};
+
+export type WorkerOrderResponse = {
+  id: string;
+  orderId: string;
+  station: StationType;
+  status: StationStatus;
+  totalItems: number;
+  updatedAt: Date;
+  createdAt: Date;
+  customerName: string | null;
+  outletName: string;
+};
+
+export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
+
+type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+export function toWorkerOrderResponse(
+  record: WorkerOrderRecord,
+): WorkerOrderResponse {
+  return {
+    id: record.id,
+    orderId: record.orderId,
+    station: record.station,
+    status: record.status,
+    totalItems: record.order.items.reduce(
+      (total, item) => total + item.quantity,
+      0,
+    ),
+    updatedAt: record.order.updatedAt,
+    createdAt: record.createdAt,
+    customerName: record.order.pickupRequest.customerUser.name ?? null,
+    outletName: record.order.outlet.name,
+  };
+}

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,0 +1,81 @@
+import { prisma } from '@/application/database';
+import type { Staff } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import {
+  type WorkerOrderListQuery,
+  toWorkerOrderResponse,
+} from './worker-order-model';
+
+const buildWorkerOrdersWhere = (staff: Staff, query: WorkerOrderListQuery) => {
+  const where: Record<string, unknown> = {
+    station: staff.workerType,
+    order: { outletId: staff.outletId },
+  };
+
+  if (query.status) where.status = query.status;
+
+  if (query.date) {
+    const startOfDay = new Date(`${query.date}T00:00:00.000Z`);
+    const endOfDay = new Date(`${query.date}T23:59:59.999Z`);
+
+    where.createdAt = {
+      gte: startOfDay,
+      lte: endOfDay,
+    };
+  }
+
+  return where;
+};
+
+const assertWorkerQueueContext = (staff: Staff) => {
+  if (!staff.outletId || !staff.workerType) {
+    throw new ResponseError(
+      422,
+      'Worker station or outlet assignment is not configured',
+    );
+  }
+};
+
+export class WorkerOrderService {
+  static async getWorkerOrders(staff: Staff, query: WorkerOrderListQuery) {
+    assertWorkerQueueContext(staff);
+
+    const skip = (query.page - 1) * query.limit;
+    const where = buildWorkerOrdersWhere(staff, query);
+
+    const [records, total] = await Promise.all([
+      prisma.stationRecord.findMany({
+        where,
+        skip,
+        take: query.limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          order: {
+            include: {
+              outlet: true,
+              pickupRequest: {
+                include: {
+                  customerUser: {
+                    select: { name: true },
+                  },
+                },
+              },
+              items: true,
+            },
+          },
+        },
+      }),
+      prisma.stationRecord.count({ where }),
+    ]);
+
+    return {
+      data: records.map(toWorkerOrderResponse),
+      meta: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    };
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,6 +12,7 @@ import { AddressController } from '@/features/addresses/address-controller';
 import { RegionController } from '@/features/region-data/region-controller';
 import { BypassRequestController } from '@/features/bypass-requests/bypass-request-controller';
 import { OrderController } from '@/features/orders/order-controller';
+import { WorkerOrderController } from '@/features/worker-orders/worker-order-controller';
 
 export const apiRouter = express.Router();
 
@@ -144,4 +145,11 @@ apiRouter.post(
   '/orders/:id/confirm',
   requireCustomerAuth,
   OrderController.confirmReceipt,
+);
+
+// WORKER
+apiRouter.get(
+  '/worker/orders',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.getOrders,
 );

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -1,0 +1,11 @@
+import { z, ZodType } from 'zod';
+import type { WorkerOrderListQuery } from '@/features/worker-orders/worker-order-model';
+
+export class WorkerOrderValidation {
+  static readonly LIST: ZodType<WorkerOrderListQuery> = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    status: z.enum(['IN_PROGRESS', 'BYPASS_REQUESTED', 'COMPLETED']).optional(),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format').optional(),
+  });
+}

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -1,0 +1,137 @@
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn(
+    (headers: Record<string, string | string[] | undefined>) => headers,
+  ),
+  toNodeHandler: jest.fn(() => (_req: any, res: any) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn() },
+    stationRecord: { findMany: jest.fn(), count: jest.fn() },
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({
+  auth: {
+    api: { getSession: jest.fn() },
+  },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+
+describe('Worker Order Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockWorkerAuth = (overrides: Partial<any> = {}) => {
+    const mockUser = { id: 'user-worker', email: 'worker@example.com' };
+    const mockStaff = {
+      id: 'staff-worker',
+      userId: 'user-worker',
+      role: 'WORKER',
+      isActive: true,
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      ...overrides,
+    };
+
+    (auth.api.getSession as jest.Mock).mockResolvedValue({
+      user: mockUser,
+      session: { id: 'session-1', expiresAt: new Date() },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  it('returns 401 when unauthenticated', async () => {
+    (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 for non-worker roles', async () => {
+    mockWorkerAuth({ role: 'OUTLET_ADMIN' });
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 400 for invalid query params', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app)
+      .get('/api/v1/worker/orders')
+      .query({ page: 0, status: 'INVALID_STATUS' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 422 when worker station or outlet is not configured', async () => {
+    mockWorkerAuth({ workerType: null });
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(422);
+    expect(response.body.errors).toBe(
+      'Worker station or outlet assignment is not configured',
+    );
+  });
+
+  it('returns paginated worker orders with standard envelope', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-1',
+        orderId: 'order-1',
+        station: 'WASHING',
+        status: 'IN_PROGRESS',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const response = await request(app)
+      .get('/api/v1/worker/orders')
+      .query({ page: 1, limit: 10, status: 'IN_PROGRESS', date: '2026-04-17' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker orders retrieved',
+      data: [
+        {
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          totalItems: 5,
+          updatedAt: '2026-04-17T10:00:00.000Z',
+          createdAt: '2026-04-17T08:00:00.000Z',
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+});

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -1,0 +1,122 @@
+jest.mock('@/application/database', () => ({
+  prisma: {
+    stationRecord: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import { WorkerOrderService } from '@/features/worker-orders/worker-order-service';
+
+describe('WorkerOrderService', () => {
+  const workerStaff = {
+    id: 'staff-worker',
+    userId: 'user-worker',
+    role: 'WORKER',
+    outletId: 'outlet-1',
+    workerType: 'WASHING',
+    isActive: true,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws 422 when worker outlet or station is not configured', async () => {
+    await expect(
+      WorkerOrderService.getWorkerOrders(
+        { ...workerStaff, outletId: null },
+        { page: 1, limit: 10 },
+      ),
+    ).rejects.toThrow(
+      new ResponseError(422, 'Worker station or outlet assignment is not configured'),
+    );
+  });
+
+  it('returns paginated worker orders', async () => {
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-1',
+        orderId: 'order-1',
+        station: 'WASHING',
+        status: 'IN_PROGRESS',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const result = await WorkerOrderService.getWorkerOrders(workerStaff, {
+      page: 1,
+      limit: 10,
+      status: 'IN_PROGRESS',
+      date: '2026-04-17',
+    });
+
+    expect(prisma.stationRecord.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          order: { outletId: 'outlet-1' },
+        }),
+        skip: 0,
+        take: 10,
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          totalItems: 5,
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          createdAt: new Date('2026-04-17T08:00:00.000Z'),
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('applies date filter boundaries to createdAt', async () => {
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(0);
+
+    await WorkerOrderService.getWorkerOrders(workerStaff, {
+      page: 2,
+      limit: 5,
+      date: '2026-04-17',
+    });
+
+    expect(prisma.stationRecord.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date('2026-04-17T00:00:00.000Z'),
+            lte: new Date('2026-04-17T23:59:59.999Z'),
+          },
+        }),
+        skip: 5,
+        take: 5,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### What changed
- added GET /api/v1/worker/orders for worker station queue
- added worker order model, validation, controller, and service
- added unit and integration tests for worker order listing
- restricted access to WORKER role only
- added pagination, status filter, and date filter support

### Why
- implements PCS-133 GET /worker/orders
- provides backend data source for worker dashboard queue in PCS-135

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/worker-order-service.test.ts --runInBand`
   - `npx jest tests/integration/worker-order-routes.test.ts --runInBand`
3. authenticate as a WORKER user
4. call `GET /api/v1/worker/orders`
5. verify response includes:
   - `status`
   - `message`
   - `data`
   - `meta`
6. test query params:
   - `page`
   - `limit`
   - `status`
   - `date`

### Notes
- frontend integration will be finalized together with PCS-134 and PCS-135 end-to-end testing
