### PR TITLE
PCS-134: add worker notification stream

### DIFF
--- a/src/features/admin-orders/admin-order-service.ts
+++ b/src/features/admin-orders/admin-order-service.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@/application/database'
 import { ResponseError } from '@/error/response-error'
+import { OrderStatus } from '@/generated/prisma/client'
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service'
 import { v4 as uuid } from 'uuid'
 import { CreateAdminOrderInput, GetAdminOrdersQuery, LaundryItemResponse } from './admin-order-model'
 
@@ -181,7 +183,8 @@ export class AdminOrderService {
           staffId: staff.id,
           pricePerKg: data.pricePerKg,
           totalWeightKg: data.totalWeightKg,
-          totalPrice
+          totalPrice,
+          status: OrderStatus.LAUNDRY_BEING_WASHED,
         }
       }),
       ...data.items.map((item) =>
@@ -195,6 +198,12 @@ export class AdminOrderService {
         })
       )
     ])
+
+    WorkerNotificationService.publishOrderArrival({
+      orderId: order.id,
+      outletId: order.outletId,
+      orderStatus: order.status,
+    })
 
     return order
   }

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -9,6 +9,7 @@ import {
   toRejectBypassResponse,
   toBypassDetailResponse,
 } from './bypass-request-model';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 import {
   advanceOrderStatus,
   assertMismatch,
@@ -93,7 +94,7 @@ export class BypassRequestService {
     password: string,
     problemDescription: string,
   ) {
-    return prisma.$transaction(async (tx) => {
+    const result = await prisma.$transaction(async (tx) => {
       const bypass = await loadAndVerifyBypass(tx, admin, bypassId, password);
       const updated = await tx.bypassRequest.update({
         where: { id: bypassId },
@@ -104,8 +105,20 @@ export class BypassRequestService {
         data: { status: StationStatus.COMPLETED, completedAt: new Date() },
       });
       const nextStatus = await advanceOrderStatus(tx, bypass.stationRecord.order);
-      return toApproveBypassResponse(updated, nextStatus);
+      return {
+        orderId: bypass.stationRecord.order.id,
+        outletId: bypass.stationRecord.order.outletId,
+        response: toApproveBypassResponse(updated, nextStatus),
+      };
     });
+
+    WorkerNotificationService.publishOrderArrival({
+      orderId: result.orderId,
+      outletId: result.outletId,
+      orderStatus: result.response.orderStatus,
+    });
+
+    return result.response;
   }
 
   static async reject(

--- a/src/features/worker-notifications/worker-notification-controller.ts
+++ b/src/features/worker-notifications/worker-notification-controller.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Response } from 'express';
+import { WorkerNotificationService } from './worker-notification-service';
+import { UserRequest } from '@/types/user-request';
+
+export class WorkerNotificationController {
+  static async stream(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      await WorkerNotificationService.subscribe(req.staff!, req, res);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/worker-notifications/worker-notification-model.ts
+++ b/src/features/worker-notifications/worker-notification-model.ts
@@ -1,0 +1,67 @@
+import {
+  OrderStatus,
+  StationType,
+  type Staff,
+} from '@/generated/prisma/client';
+
+export const WORKER_NOTIFICATION_CONNECTED_EVENT = 'worker-notification-connected';
+export const WORKER_ORDER_ARRIVED_EVENT = 'worker-order-arrived';
+export const WORKER_NOTIFICATION_PING_EVENT = 'worker-notification-ping';
+export const WORKER_NOTIFICATION_PING_MS = 25_000;
+
+export type WorkerNotificationStation = `${StationType}`;
+
+export interface WorkerOrderArrivalPayload {
+  event: typeof WORKER_ORDER_ARRIVED_EVENT;
+  orderId: string;
+  outletId: string;
+  station: WorkerNotificationStation;
+  orderStatus: string;
+  occurredAt: string;
+}
+
+export interface WorkerNotificationSubscriber {
+  id: string;
+  outletId: string;
+  station: WorkerNotificationStation;
+}
+
+export interface WorkerNotificationContext {
+  orderId: string;
+  outletId: string;
+  orderStatus: string;
+}
+
+export const resolveStationFromOrderStatus = (
+  orderStatus: string,
+): WorkerNotificationStation | null => {
+  if (orderStatus === OrderStatus.LAUNDRY_BEING_WASHED) return StationType.WASHING;
+  if (orderStatus === OrderStatus.LAUNDRY_BEING_IRONED) return StationType.IRONING;
+  if (orderStatus === OrderStatus.LAUNDRY_BEING_PACKED) return StationType.PACKING;
+  return null;
+};
+
+export const toWorkerSubscriber = (
+  staff: Staff,
+  id: string,
+): WorkerNotificationSubscriber => ({
+  id,
+  outletId: staff.outletId!,
+  station: staff.workerType!,
+});
+
+export const toWorkerOrderArrivalPayload = (
+  data: WorkerNotificationContext,
+): WorkerOrderArrivalPayload | null => {
+  const station = resolveStationFromOrderStatus(data.orderStatus);
+  if (!station) return null;
+
+  return {
+    event: WORKER_ORDER_ARRIVED_EVENT,
+    orderId: data.orderId,
+    outletId: data.outletId,
+    station,
+    orderStatus: data.orderStatus,
+    occurredAt: new Date().toISOString(),
+  };
+};

--- a/src/features/worker-notifications/worker-notification-service.ts
+++ b/src/features/worker-notifications/worker-notification-service.ts
@@ -1,0 +1,104 @@
+import { Response } from 'express';
+import { ResponseError } from '@/error/response-error';
+import type { UserRequest } from '@/types/user-request';
+import type { Staff } from '@/generated/prisma/client';
+import {
+  WORKER_NOTIFICATION_CONNECTED_EVENT,
+  WORKER_NOTIFICATION_PING_EVENT,
+  WORKER_NOTIFICATION_PING_MS,
+  type WorkerNotificationContext,
+  type WorkerNotificationSubscriber,
+  toWorkerOrderArrivalPayload,
+  toWorkerSubscriber,
+} from './worker-notification-model';
+
+interface WorkerConnection {
+  subscriber: WorkerNotificationSubscriber;
+  response: Response;
+  heartbeat: NodeJS.Timeout;
+}
+
+const assertWorkerNotificationContext = (staff: Staff) => {
+  if (!staff.outletId || !staff.workerType) {
+    throw new ResponseError(
+      422,
+      'Worker station or outlet assignment is not configured',
+    );
+  }
+};
+
+const writeSseEvent = (
+  response: Response,
+  event: string,
+  payload: unknown,
+) => {
+  response.write(`event: ${event}\n`);
+  response.write(`data: ${JSON.stringify(payload)}\n\n`);
+};
+
+export class WorkerNotificationService {
+  private static connections = new Map<string, WorkerConnection>();
+
+  static async subscribe(staff: Staff, req: UserRequest, res: Response) {
+    assertWorkerNotificationContext(staff);
+
+    const subscriber = toWorkerSubscriber(
+      staff,
+      `${staff.id}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    );
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders?.();
+
+    writeSseEvent(res, WORKER_NOTIFICATION_CONNECTED_EVENT, {
+      station: subscriber.station,
+      outletId: subscriber.outletId,
+    });
+
+    const heartbeat = setInterval(() => {
+      writeSseEvent(res, WORKER_NOTIFICATION_PING_EVENT, {
+        timestamp: new Date().toISOString(),
+      });
+    }, WORKER_NOTIFICATION_PING_MS);
+
+    this.connections.set(subscriber.id, {
+      subscriber,
+      response: res,
+      heartbeat,
+    });
+
+    req.on('close', () => this.unsubscribe(subscriber.id));
+  }
+
+  static publishOrderArrival(data: WorkerNotificationContext) {
+    const payload = toWorkerOrderArrivalPayload(data);
+    if (!payload) return;
+
+    this.connections.forEach((connection) => {
+      const { subscriber, response } = connection;
+      if (subscriber.outletId !== payload.outletId) return;
+      if (subscriber.station !== payload.station) return;
+      writeSseEvent(response, payload.event, payload);
+    });
+  }
+
+  static unsubscribe(connectionId: string) {
+    const connection = this.connections.get(connectionId);
+    if (!connection) return;
+
+    clearInterval(connection.heartbeat);
+    connection.response.end();
+    this.connections.delete(connectionId);
+  }
+
+  static reset() {
+    this.connections.forEach((connection) => {
+      clearInterval(connection.heartbeat);
+      connection.response.end();
+    });
+    this.connections.clear();
+  }
+}

--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Response } from 'express';
+import { Validation } from '@/validations/validation';
+import { WorkerOrderValidation } from '@/validations/worker-order-validation';
+import { UserRequest } from '@/types/user-request';
+import { WorkerOrderService } from './worker-order-service';
+
+export class WorkerOrderController {
+  static async getOrders(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(WorkerOrderValidation.LIST, req.query);
+      const result = await WorkerOrderService.getWorkerOrders(req.staff!, query);
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker orders retrieved',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -1,0 +1,61 @@
+import type { Prisma, Staff, StationStatus, StationType } from '@/generated/prisma/client';
+
+export type WorkerOrderListQuery = {
+  page: number;
+  limit: number;
+  status?: StationStatus;
+  date?: string;
+};
+
+export type WorkerOrderResponse = {
+  id: string;
+  orderId: string;
+  station: StationType;
+  status: StationStatus;
+  totalItems: number;
+  updatedAt: Date;
+  createdAt: Date;
+  customerName: string | null;
+  outletName: string;
+};
+
+export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
+
+type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+export function toWorkerOrderResponse(
+  record: WorkerOrderRecord,
+): WorkerOrderResponse {
+  return {
+    id: record.id,
+    orderId: record.orderId,
+    station: record.station,
+    status: record.status,
+    totalItems: record.order.items.reduce(
+      (total, item) => total + item.quantity,
+      0,
+    ),
+    updatedAt: record.order.updatedAt,
+    createdAt: record.createdAt,
+    customerName: record.order.pickupRequest.customerUser.name ?? null,
+    outletName: record.order.outlet.name,
+  };
+}

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,0 +1,81 @@
+import { prisma } from '@/application/database';
+import type { Staff } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import {
+  type WorkerOrderListQuery,
+  toWorkerOrderResponse,
+} from './worker-order-model';
+
+const buildWorkerOrdersWhere = (staff: Staff, query: WorkerOrderListQuery) => {
+  const where: Record<string, unknown> = {
+    station: staff.workerType,
+    order: { outletId: staff.outletId },
+  };
+
+  if (query.status) where.status = query.status;
+
+  if (query.date) {
+    const startOfDay = new Date(`${query.date}T00:00:00.000Z`);
+    const endOfDay = new Date(`${query.date}T23:59:59.999Z`);
+
+    where.createdAt = {
+      gte: startOfDay,
+      lte: endOfDay,
+    };
+  }
+
+  return where;
+};
+
+const assertWorkerQueueContext = (staff: Staff) => {
+  if (!staff.outletId || !staff.workerType) {
+    throw new ResponseError(
+      422,
+      'Worker station or outlet assignment is not configured',
+    );
+  }
+};
+
+export class WorkerOrderService {
+  static async getWorkerOrders(staff: Staff, query: WorkerOrderListQuery) {
+    assertWorkerQueueContext(staff);
+
+    const skip = (query.page - 1) * query.limit;
+    const where = buildWorkerOrdersWhere(staff, query);
+
+    const [records, total] = await Promise.all([
+      prisma.stationRecord.findMany({
+        where,
+        skip,
+        take: query.limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          order: {
+            include: {
+              outlet: true,
+              pickupRequest: {
+                include: {
+                  customerUser: {
+                    select: { name: true },
+                  },
+                },
+              },
+              items: true,
+            },
+          },
+        },
+      }),
+      prisma.stationRecord.count({ where }),
+    ]);
+
+    return {
+      data: records.map(toWorkerOrderResponse),
+      meta: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    };
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -13,6 +13,7 @@ import { RegionController } from '@/features/region-data/region-controller';
 import { BypassRequestController } from '@/features/bypass-requests/bypass-request-controller';
 import { OrderController } from '@/features/orders/order-controller';
 import { WorkerOrderController } from '@/features/worker-orders/worker-order-controller';
+import { WorkerNotificationController } from '@/features/worker-notifications/worker-notification-controller';
 
 export const apiRouter = express.Router();
 
@@ -152,4 +153,9 @@ apiRouter.get(
   '/worker/orders',
   requireStaffRole('WORKER'),
   WorkerOrderController.getOrders,
+);
+apiRouter.get(
+  '/worker/notifications/stream',
+  requireStaffRole('WORKER'),
+  WorkerNotificationController.stream,
 );

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,6 +12,7 @@ import { AddressController } from '@/features/addresses/address-controller';
 import { RegionController } from '@/features/region-data/region-controller';
 import { BypassRequestController } from '@/features/bypass-requests/bypass-request-controller';
 import { OrderController } from '@/features/orders/order-controller';
+import { WorkerOrderController } from '@/features/worker-orders/worker-order-controller';
 
 export const apiRouter = express.Router();
 
@@ -144,4 +145,11 @@ apiRouter.post(
   '/orders/:id/confirm',
   requireCustomerAuth,
   OrderController.confirmReceipt,
+);
+
+// WORKER
+apiRouter.get(
+  '/worker/orders',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.getOrders,
 );

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -1,0 +1,11 @@
+import { z, ZodType } from 'zod';
+import type { WorkerOrderListQuery } from '@/features/worker-orders/worker-order-model';
+
+export class WorkerOrderValidation {
+  static readonly LIST: ZodType<WorkerOrderListQuery> = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    status: z.enum(['IN_PROGRESS', 'BYPASS_REQUESTED', 'COMPLETED']).optional(),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format').optional(),
+  });
+}

--- a/tests/integration/worker-notification-routes.test.ts
+++ b/tests/integration/worker-notification-routes.test.ts
@@ -1,0 +1,92 @@
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn(
+    (headers: Record<string, string | string[] | undefined>) => headers,
+  ),
+  toNodeHandler: jest.fn(() => (_req: any, res: any) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({
+  auth: {
+    api: { getSession: jest.fn() },
+  },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
+
+describe('Worker Notification Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockWorkerAuth = (overrides: Partial<any> = {}) => {
+    const mockUser = { id: 'user-worker', email: 'worker@example.com' };
+    const mockStaff = {
+      id: 'staff-worker',
+      userId: 'user-worker',
+      role: 'WORKER',
+      isActive: true,
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      ...overrides,
+    };
+
+    (auth.api.getSession as jest.Mock).mockResolvedValue({
+      user: mockUser,
+      session: { id: 'session-1', expiresAt: new Date() },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  it('returns 401 when unauthenticated', async () => {
+    (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/v1/worker/notifications/stream');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 for non-worker roles', async () => {
+    mockWorkerAuth({ role: 'OUTLET_ADMIN' });
+
+    const response = await request(app).get('/api/v1/worker/notifications/stream');
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 422 when worker station or outlet is not configured', async () => {
+    mockWorkerAuth({ workerType: null });
+
+    const response = await request(app).get('/api/v1/worker/notifications/stream');
+
+    expect(response.status).toBe(422);
+    expect(response.body.errors).toBe(
+      'Worker station or outlet assignment is not configured',
+    );
+  });
+
+  it('opens the worker notification stream for a valid worker', async () => {
+    mockWorkerAuth();
+    jest
+      .spyOn(WorkerNotificationService, 'subscribe')
+      .mockImplementation(async (_staff, _req, res) => {
+        res.status(200).json({ status: 'success', message: 'stream-opened' });
+      });
+
+    const response = await request(app).get('/api/v1/worker/notifications/stream');
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('stream-opened');
+  });
+});

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -1,0 +1,137 @@
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn(
+    (headers: Record<string, string | string[] | undefined>) => headers,
+  ),
+  toNodeHandler: jest.fn(() => (_req: any, res: any) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn() },
+    stationRecord: { findMany: jest.fn(), count: jest.fn() },
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({
+  auth: {
+    api: { getSession: jest.fn() },
+  },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+
+describe('Worker Order Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockWorkerAuth = (overrides: Partial<any> = {}) => {
+    const mockUser = { id: 'user-worker', email: 'worker@example.com' };
+    const mockStaff = {
+      id: 'staff-worker',
+      userId: 'user-worker',
+      role: 'WORKER',
+      isActive: true,
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      ...overrides,
+    };
+
+    (auth.api.getSession as jest.Mock).mockResolvedValue({
+      user: mockUser,
+      session: { id: 'session-1', expiresAt: new Date() },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  it('returns 401 when unauthenticated', async () => {
+    (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 for non-worker roles', async () => {
+    mockWorkerAuth({ role: 'OUTLET_ADMIN' });
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 400 for invalid query params', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app)
+      .get('/api/v1/worker/orders')
+      .query({ page: 0, status: 'INVALID_STATUS' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 422 when worker station or outlet is not configured', async () => {
+    mockWorkerAuth({ workerType: null });
+
+    const response = await request(app).get('/api/v1/worker/orders');
+
+    expect(response.status).toBe(422);
+    expect(response.body.errors).toBe(
+      'Worker station or outlet assignment is not configured',
+    );
+  });
+
+  it('returns paginated worker orders with standard envelope', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-1',
+        orderId: 'order-1',
+        station: 'WASHING',
+        status: 'IN_PROGRESS',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const response = await request(app)
+      .get('/api/v1/worker/orders')
+      .query({ page: 1, limit: 10, status: 'IN_PROGRESS', date: '2026-04-17' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker orders retrieved',
+      data: [
+        {
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          totalItems: 5,
+          updatedAt: '2026-04-17T10:00:00.000Z',
+          createdAt: '2026-04-17T08:00:00.000Z',
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+});

--- a/tests/unit/admin-order-service.test.ts
+++ b/tests/unit/admin-order-service.test.ts
@@ -7,8 +7,15 @@ jest.mock('@/application/database', () => ({
   },
 }));
 
+jest.mock('@/features/worker-notifications/worker-notification-service', () => ({
+  WorkerNotificationService: {
+    publishOrderArrival: jest.fn(),
+  },
+}));
+
 import { AdminOrderService } from '@/features/admin-orders/admin-order-service';
 import { prisma } from '@/application/database';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 
 const superAdmin = { id: 'staff-sa', role: 'SUPER_ADMIN', outletId: null };
 const outletAdmin = { id: 'staff-oa', role: 'OUTLET_ADMIN', outletId: 'outlet-1' };
@@ -245,7 +252,7 @@ describe('AdminOrderService', () => {
       ],
     };
     const mockPickup = { id: VALID_UUID, outletId: 'outlet-1', status: 'PICKED_UP', order: null };
-    const mockOrder = { id: 'order-new', outletId: 'outlet-1' };
+    const mockOrder = { id: 'order-new', outletId: 'outlet-1', status: 'LAUNDRY_BEING_WASHED' };
 
     it('should create order atomically via $transaction and return the order', async () => {
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
@@ -295,6 +302,34 @@ describe('AdminOrderService', () => {
       expect(txArgs).toHaveLength(1 + validInput.items.length);
     });
 
+    it('should set created order status to LAUNDRY_BEING_WASHED', async () => {
+      (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
+      (prisma.order.create as jest.Mock).mockResolvedValue(mockOrder);
+      (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
+
+      await AdminOrderService.createAdminOrder(superAdmin, validInput);
+
+      expect(prisma.order.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'LAUNDRY_BEING_WASHED' }),
+        }),
+      );
+    });
+
+    it('should publish a worker arrival notification after order creation', async () => {
+      (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
+      (prisma.order.create as jest.Mock).mockResolvedValue(mockOrder);
+      (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
+
+      await AdminOrderService.createAdminOrder(superAdmin, validInput);
+
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'order-new',
+        outletId: 'outlet-1',
+        orderStatus: 'LAUNDRY_BEING_WASHED',
+      });
+    });
+
     it('should throw 404 when pickupRequest not found', async () => {
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(null);
 
@@ -337,7 +372,11 @@ describe('AdminOrderService', () => {
         ...mockPickup,
         outletId: 'outlet-other',
       });
-      (prisma.order.create as jest.Mock).mockResolvedValue({ id: 'order-new', outletId: 'outlet-other' });
+      (prisma.order.create as jest.Mock).mockResolvedValue({
+        id: 'order-new',
+        outletId: 'outlet-other',
+        status: 'LAUNDRY_BEING_WASHED',
+      });
       (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
 
       const result = await AdminOrderService.createAdminOrder(superAdmin, validInput);

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -49,10 +49,17 @@ jest.mock('@/application/database', () => ({
   },
 }));
 
+jest.mock('@/features/worker-notifications/worker-notification-service', () => ({
+  WorkerNotificationService: {
+    publishOrderArrival: jest.fn(),
+  },
+}));
+
 import { BypassRequestService } from '@/features/bypass-requests/bypass-request-service';
 import { prisma } from '@/application/database';
 import { ResponseError } from '@/error/response-error';
 import bcrypt from 'bcrypt';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 
 describe('BypassRequestService', () => {
   beforeEach(() => {
@@ -505,6 +512,11 @@ describe('BypassRequestService', () => {
       const result = await approve();
 
       expect(mockTx.order.update).toHaveBeenCalledWith({ where: { id: 'ord-1' }, data: { status: 'LAUNDRY_BEING_IRONED' } });
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'ord-1',
+        outletId: 'outlet-1',
+        orderStatus: 'LAUNDRY_BEING_IRONED',
+      });
       expect(result.orderStatus).toBe('LAUNDRY_BEING_IRONED');
     });
 
@@ -519,6 +531,11 @@ describe('BypassRequestService', () => {
       const result = await approve();
 
       expect(mockTx.order.update).toHaveBeenCalledWith(expect.objectContaining({ data: { status: 'LAUNDRY_BEING_PACKED' } }));
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'ord-1',
+        outletId: 'outlet-1',
+        orderStatus: 'LAUNDRY_BEING_PACKED',
+      });
       expect(result.orderStatus).toBe('LAUNDRY_BEING_PACKED');
     });
 
@@ -533,6 +550,11 @@ describe('BypassRequestService', () => {
       const result = await approve();
 
       expect(result.orderStatus).toBe('WAITING_FOR_PAYMENT');
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'ord-1',
+        outletId: 'outlet-1',
+        orderStatus: 'WAITING_FOR_PAYMENT',
+      });
       expect(mockTx.delivery.create).not.toHaveBeenCalled();
     });
 
@@ -548,6 +570,11 @@ describe('BypassRequestService', () => {
       const result = await approve();
 
       expect(result.orderStatus).toBe('LAUNDRY_READY_FOR_DELIVERY');
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'ord-1',
+        outletId: 'outlet-1',
+        orderStatus: 'LAUNDRY_READY_FOR_DELIVERY',
+      });
       expect(mockTx.delivery.create).toHaveBeenCalledWith({ data: { orderId: 'ord-1' } });
     });
   });

--- a/tests/unit/worker-notification-service.test.ts
+++ b/tests/unit/worker-notification-service.test.ts
@@ -1,0 +1,121 @@
+import { EventEmitter } from 'events';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
+import {
+  WORKER_NOTIFICATION_CONNECTED_EVENT,
+  WORKER_ORDER_ARRIVED_EVENT,
+} from '@/features/worker-notifications/worker-notification-model';
+
+const createResponse = () => ({
+  end: jest.fn(),
+  setHeader: jest.fn(),
+  flushHeaders: jest.fn(),
+  write: jest.fn(),
+});
+
+describe('WorkerNotificationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    WorkerNotificationService.reset();
+  });
+
+  it('throws 422 when worker station or outlet is missing', async () => {
+    const request = new EventEmitter() as any;
+    const response = createResponse() as any;
+
+    await expect(
+      WorkerNotificationService.subscribe(
+        {
+          id: 'staff-1',
+          outletId: null,
+          workerType: null,
+        } as any,
+        request,
+        response,
+      ),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it('subscribes a worker and writes an initial connected event', async () => {
+    const request = new EventEmitter() as any;
+    const response = createResponse() as any;
+
+    await WorkerNotificationService.subscribe(
+      {
+        id: 'staff-1',
+        outletId: 'outlet-1',
+        workerType: 'WASHING',
+      } as any,
+      request,
+      response,
+    );
+
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/event-stream',
+    );
+    expect(response.write).toHaveBeenNthCalledWith(
+      1,
+      `event: ${WORKER_NOTIFICATION_CONNECTED_EVENT}\n`,
+    );
+  });
+
+  it('publishes arrival events only to the matching outlet and station', async () => {
+    const washingRequest = new EventEmitter() as any;
+    const ironingRequest = new EventEmitter() as any;
+    const washingResponse = createResponse() as any;
+    const ironingResponse = createResponse() as any;
+
+    await WorkerNotificationService.subscribe(
+      {
+        id: 'staff-washing',
+        outletId: 'outlet-1',
+        workerType: 'WASHING',
+      } as any,
+      washingRequest,
+      washingResponse,
+    );
+    await WorkerNotificationService.subscribe(
+      {
+        id: 'staff-ironing',
+        outletId: 'outlet-1',
+        workerType: 'IRONING',
+      } as any,
+      ironingRequest,
+      ironingResponse,
+    );
+
+    washingResponse.write.mockClear();
+    ironingResponse.write.mockClear();
+
+    WorkerNotificationService.publishOrderArrival({
+      orderId: 'order-1',
+      outletId: 'outlet-1',
+      orderStatus: 'LAUNDRY_BEING_WASHED',
+    });
+
+    expect(washingResponse.write).toHaveBeenNthCalledWith(
+      1,
+      `event: ${WORKER_ORDER_ARRIVED_EVENT}\n`,
+    );
+    expect(ironingResponse.write).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the connection when the request closes', async () => {
+    const request = new EventEmitter() as any;
+    const response = createResponse() as any;
+
+    await WorkerNotificationService.subscribe(
+      {
+        id: 'staff-1',
+        outletId: 'outlet-1',
+        workerType: 'WASHING',
+      } as any,
+      request,
+      response,
+    );
+
+    request.emit('close');
+
+    expect(response.end).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -1,0 +1,122 @@
+jest.mock('@/application/database', () => ({
+  prisma: {
+    stationRecord: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import { WorkerOrderService } from '@/features/worker-orders/worker-order-service';
+
+describe('WorkerOrderService', () => {
+  const workerStaff = {
+    id: 'staff-worker',
+    userId: 'user-worker',
+    role: 'WORKER',
+    outletId: 'outlet-1',
+    workerType: 'WASHING',
+    isActive: true,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws 422 when worker outlet or station is not configured', async () => {
+    await expect(
+      WorkerOrderService.getWorkerOrders(
+        { ...workerStaff, outletId: null },
+        { page: 1, limit: 10 },
+      ),
+    ).rejects.toThrow(
+      new ResponseError(422, 'Worker station or outlet assignment is not configured'),
+    );
+  });
+
+  it('returns paginated worker orders', async () => {
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-1',
+        orderId: 'order-1',
+        station: 'WASHING',
+        status: 'IN_PROGRESS',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const result = await WorkerOrderService.getWorkerOrders(workerStaff, {
+      page: 1,
+      limit: 10,
+      status: 'IN_PROGRESS',
+      date: '2026-04-17',
+    });
+
+    expect(prisma.stationRecord.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          order: { outletId: 'outlet-1' },
+        }),
+        skip: 0,
+        take: 10,
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+          totalItems: 5,
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          createdAt: new Date('2026-04-17T08:00:00.000Z'),
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('applies date filter boundaries to createdAt', async () => {
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(0);
+
+    await WorkerOrderService.getWorkerOrders(workerStaff, {
+      page: 2,
+      limit: 5,
+      date: '2026-04-17',
+    });
+
+    expect(prisma.stationRecord.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date('2026-04-17T00:00:00.000Z'),
+            lte: new Date('2026-04-17T23:59:59.999Z'),
+          },
+        }),
+        skip: 5,
+        take: 5,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### What changed
- added SSE endpoint for worker notifications at GET /api/v1/worker/notifications/stream
- added worker notification model, controller, and in-memory stream service
- published worker arrival events when a new order starts washing
- published worker arrival events when bypass approval advances an order to the next station
- added unit and integration tests for worker notifications

### Why
- implements PCS-134 setup worker notifications
- allows worker clients to receive station-specific order arrival events in real time

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/worker-notification-service.test.ts --runInBand`
   - `npx jest tests/integration/worker-notification-routes.test.ts --runInBand`
   - `npx jest tests/unit/admin-order-service.test.ts --runInBand`
   - `npx jest tests/unit/bypass-request-service.test.ts --runInBand`
3. authenticate as a WORKER user
4. open `GET /api/v1/worker/notifications/stream`
5. verify SSE headers are returned
6. create a new admin order and confirm a washing notification is emitted
7. approve a bypass request and confirm the next station receives a notification

### Notes
- this PR is based on PCS-133 and should be reviewed after or together with the worker order queue endpoint
