### PR TITLE
feat: add worker order detail endpoint

### DIFF
--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -20,4 +20,29 @@ export class WorkerOrderController {
       next(error);
     }
   }
+
+  static async getOrderDetail(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const orderId = Validation.validate(
+        WorkerOrderValidation.ID_PARAM,
+        req.params.id,
+      );
+      const result = await WorkerOrderService.getWorkerOrderDetail(
+        req.staff!,
+        orderId,
+      );
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker order retrieved',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -1,4 +1,11 @@
-import type { Prisma, Staff, StationStatus, StationType } from '@/generated/prisma/client';
+import type {
+  OrderPaymentStatus,
+  OrderStatus,
+  Prisma,
+  Staff,
+  StationStatus,
+  StationType,
+} from '@/generated/prisma/client';
 
 export type WorkerOrderListQuery = {
   page: number;
@@ -17,6 +24,29 @@ export type WorkerOrderResponse = {
   createdAt: Date;
   customerName: string | null;
   outletName: string;
+};
+
+export type WorkerOrderItemResponse = {
+  laundryItemId: string;
+  itemName: string;
+  quantity: number;
+};
+
+export type WorkerOrderDetailResponse = {
+  orderId: string;
+  stationRecordId: string;
+  station: StationType;
+  previousStation: StationType | null;
+  stationStatus: StationStatus;
+  orderStatus: OrderStatus;
+  paymentStatus: OrderPaymentStatus;
+  totalItems: number;
+  customerName: string | null;
+  outletName: string;
+  createdAt: Date;
+  updatedAt: Date;
+  referenceItems: WorkerOrderItemResponse[];
+  stationItems: WorkerOrderItemResponse[];
 };
 
 export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
@@ -41,6 +71,49 @@ type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
   };
 }>;
 
+type WorkerOrderDetailRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    stationItems: {
+      include: {
+        laundryItem: {
+          select: {
+            name: true;
+          };
+        };
+      };
+    };
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+const getPreviousStation = (station: StationType): StationType | null => {
+  if (station === 'WASHING') return null;
+  if (station === 'IRONING') return 'WASHING';
+  return 'IRONING';
+};
+
+const toWorkerOrderItemResponse = (
+  item: { laundryItemId: string; quantity: number; laundryItem: { name: string } },
+): WorkerOrderItemResponse => ({
+  laundryItemId: item.laundryItemId,
+  itemName: item.laundryItem.name,
+  quantity: item.quantity,
+});
+
 export function toWorkerOrderResponse(
   record: WorkerOrderRecord,
 ): WorkerOrderResponse {
@@ -57,5 +130,30 @@ export function toWorkerOrderResponse(
     createdAt: record.createdAt,
     customerName: record.order.pickupRequest.customerUser.name ?? null,
     outletName: record.order.outlet.name,
+  };
+}
+
+export function toWorkerOrderDetailResponse(
+  record: WorkerOrderDetailRecord,
+  referenceItems: WorkerOrderItemResponse[],
+): WorkerOrderDetailResponse {
+  return {
+    orderId: record.orderId,
+    stationRecordId: record.id,
+    station: record.station,
+    previousStation: getPreviousStation(record.station),
+    stationStatus: record.status,
+    orderStatus: record.order.status,
+    paymentStatus: record.order.paymentStatus,
+    totalItems: record.order.items.reduce(
+      (total, item) => total + item.quantity,
+      0,
+    ),
+    customerName: record.order.pickupRequest.customerUser.name ?? null,
+    outletName: record.order.outlet.name,
+    createdAt: record.createdAt,
+    updatedAt: record.order.updatedAt,
+    referenceItems,
+    stationItems: record.stationItems.map(toWorkerOrderItemResponse),
   };
 }

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,7 +1,9 @@
 import { prisma } from '@/application/database';
 import type { Staff } from '@/generated/prisma/client';
 import { ResponseError } from '@/error/response-error';
+import { fetchReferenceItems } from '@/features/bypass-requests/bypass-request-helpers';
 import {
+  toWorkerOrderDetailResponse,
   type WorkerOrderListQuery,
   toWorkerOrderResponse,
 } from './worker-order-model';
@@ -27,21 +29,29 @@ const buildWorkerOrdersWhere = (staff: Staff, query: WorkerOrderListQuery) => {
   return where;
 };
 
-const assertWorkerQueueContext = (staff: Staff) => {
+const getWorkerQueueContext = (staff: Staff) => {
   if (!staff.outletId || !staff.workerType) {
     throw new ResponseError(
       422,
       'Worker station or outlet assignment is not configured',
     );
   }
+
+  return {
+    outletId: staff.outletId,
+    workerType: staff.workerType,
+  };
 };
 
 export class WorkerOrderService {
   static async getWorkerOrders(staff: Staff, query: WorkerOrderListQuery) {
-    assertWorkerQueueContext(staff);
+    const queueContext = getWorkerQueueContext(staff);
 
     const skip = (query.page - 1) * query.limit;
-    const where = buildWorkerOrdersWhere(staff, query);
+    const where = buildWorkerOrdersWhere(
+      { ...staff, ...queueContext },
+      query,
+    );
 
     const [records, total] = await Promise.all([
       prisma.stationRecord.findMany({
@@ -77,5 +87,50 @@ export class WorkerOrderService {
         totalPages: Math.ceil(total / query.limit),
       },
     };
+  }
+
+  static async getWorkerOrderDetail(staff: Staff, orderId: string) {
+    const queueContext = getWorkerQueueContext(staff);
+
+    const record = await prisma.stationRecord.findFirst({
+      where: {
+        orderId,
+        station: queueContext.workerType,
+        order: { outletId: queueContext.outletId },
+      },
+      include: {
+        stationItems: {
+          include: {
+            laundryItem: {
+              select: { name: true },
+            },
+          },
+        },
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    });
+
+    if (!record) {
+      throw new ResponseError(404, 'Worker order not found');
+    }
+
+    const referenceItems = await fetchReferenceItems(orderId, record.station);
+
+    return toWorkerOrderDetailResponse(
+      record as Parameters<typeof toWorkerOrderDetailResponse>[0],
+      referenceItems,
+    );
   }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -155,6 +155,11 @@ apiRouter.get(
   WorkerOrderController.getOrders,
 );
 apiRouter.get(
+  '/worker/orders/:id',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.getOrderDetail,
+);
+apiRouter.get(
   '/worker/notifications/stream',
   requireStaffRole('WORKER'),
   WorkerNotificationController.stream,

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -2,6 +2,8 @@ import { z, ZodType } from 'zod';
 import type { WorkerOrderListQuery } from '@/features/worker-orders/worker-order-model';
 
 export class WorkerOrderValidation {
+  static readonly ID_PARAM: ZodType<string> = z.uuid();
+
   static readonly LIST: ZodType<WorkerOrderListQuery> = z.object({
     page: z.coerce.number().int().min(1).default(1),
     limit: z.coerce.number().int().min(1).max(100).default(10),

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -9,7 +9,8 @@ jest.mock('@/application/database', () => ({
   prisma: {
     user: { findUnique: jest.fn() },
     staff: { findUnique: jest.fn() },
-    stationRecord: { findMany: jest.fn(), count: jest.fn() },
+    stationRecord: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    orderItem: { findMany: jest.fn() },
   },
 }));
 
@@ -131,6 +132,97 @@ describe('Worker Order Routes', () => {
         limit: 10,
         total: 1,
         totalPages: 1,
+      },
+    });
+  });
+
+  it('returns 400 for invalid worker order id param', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app).get('/api/v1/worker/orders/not-a-uuid');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 when worker order detail is not found', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get(
+      '/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.errors).toBe('Worker order not found');
+  });
+
+  it('returns worker order detail with comparison items', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue({
+      id: 'station-record-1',
+      orderId: '123e4567-e89b-12d3-a456-426614174000',
+      station: 'WASHING',
+      status: 'IN_PROGRESS',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          quantity: 4,
+          laundryItem: { name: 'Shirt' },
+        },
+      ],
+      order: {
+        status: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+        outlet: { name: 'PrimeCare BSD' },
+        pickupRequest: { customerUser: { name: 'John Doe' } },
+        items: [{ quantity: 2 }, { quantity: 3 }],
+      },
+    });
+    (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+      {
+        laundryItemId: 'item-1',
+        quantity: 5,
+        laundryItem: { name: 'Shirt' },
+      },
+    ]);
+
+    const response = await request(app).get(
+      '/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker order retrieved',
+      data: {
+        orderId: '123e4567-e89b-12d3-a456-426614174000',
+        stationRecordId: 'station-record-1',
+        station: 'WASHING',
+        previousStation: null,
+        stationStatus: 'IN_PROGRESS',
+        orderStatus: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        totalItems: 5,
+        customerName: 'John Doe',
+        outletName: 'PrimeCare BSD',
+        createdAt: '2026-04-17T08:00:00.000Z',
+        updatedAt: '2026-04-17T10:00:00.000Z',
+        referenceItems: [
+          {
+            laundryItemId: 'item-1',
+            itemName: 'Shirt',
+            quantity: 5,
+          },
+        ],
+        stationItems: [
+          {
+            laundryItemId: 'item-1',
+            itemName: 'Shirt',
+            quantity: 4,
+          },
+        ],
       },
     });
   });

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -3,6 +3,10 @@ jest.mock('@/application/database', () => ({
     stationRecord: {
       findMany: jest.fn(),
       count: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    orderItem: {
+      findMany: jest.fn(),
     },
   },
 }));
@@ -118,5 +122,108 @@ describe('WorkerOrderService', () => {
         take: 5,
       }),
     );
+  });
+
+  it('returns worker order detail with reference items for washing station', async () => {
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue({
+      id: 'station-record-1',
+      orderId: 'order-1',
+      station: 'WASHING',
+      status: 'IN_PROGRESS',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          quantity: 4,
+          laundryItem: { name: 'Shirt' },
+        },
+      ],
+      order: {
+        status: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+        outlet: { name: 'PrimeCare BSD' },
+        pickupRequest: { customerUser: { name: 'John Doe' } },
+        items: [{ quantity: 2 }, { quantity: 3 }],
+      },
+    });
+    (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+      {
+        laundryItemId: 'item-1',
+        quantity: 5,
+        laundryItem: { name: 'Shirt' },
+      },
+    ]);
+
+    const result = await WorkerOrderService.getWorkerOrderDetail(
+      workerStaff,
+      'order-1',
+    );
+
+    expect(prisma.stationRecord.findFirst).toHaveBeenCalledWith({
+      where: {
+        orderId: 'order-1',
+        station: 'WASHING',
+        order: { outletId: 'outlet-1' },
+      },
+      include: {
+        stationItems: {
+          include: {
+            laundryItem: {
+              select: { name: true },
+            },
+          },
+        },
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    });
+    expect(result).toEqual({
+      orderId: 'order-1',
+      stationRecordId: 'station-record-1',
+      station: 'WASHING',
+      previousStation: null,
+      stationStatus: 'IN_PROGRESS',
+      orderStatus: 'LAUNDRY_BEING_WASHED',
+      paymentStatus: 'UNPAID',
+      totalItems: 5,
+      customerName: 'John Doe',
+      outletName: 'PrimeCare BSD',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+      referenceItems: [
+        {
+          laundryItemId: 'item-1',
+          itemName: 'Shirt',
+          quantity: 5,
+        },
+      ],
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          itemName: 'Shirt',
+          quantity: 4,
+        },
+      ],
+    });
+  });
+
+  it('throws 404 when worker order detail is not found', async () => {
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      WorkerOrderService.getWorkerOrderDetail(workerStaff, 'order-404'),
+    ).rejects.toThrow(new ResponseError(404, 'Worker order not found'));
   });
 });


### PR DESCRIPTION
### What changed
- added `GET /api/v1/worker/orders/:id` for worker order detail
- added worker order detail response with:
  - station record context
  - order status and payment status
  - customer and outlet info
  - `referenceItems` for quantity comparison
  - current `stationItems`
- added UUID param validation for worker order detail
- added unit and integration test coverage for the new endpoint

### Why
- implements PCS-136 `GET /worker/orders/:id`
- provides the worker process page with order detail and previous-station item reference needed for quantity comparison

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/worker-order-service.test.ts --runInBand`
   - `npx jest tests/integration/worker-order-routes.test.ts --runInBand`
3. authenticate as a `WORKER`
4. call `GET /api/v1/worker/orders/:id`
5. verify the response includes:
   - `orderId`
   - `stationRecordId`
   - `station`
   - `previousStation`
   - `stationStatus`
   - `orderStatus`
   - `paymentStatus`
   - `referenceItems`
   - `stationItems`

### Notes
- `referenceItems` follow the same comparison rule already used by bypass flow:
  - `WASHING` reads from `orderItems`
  - `IRONING` reads from completed `WASHING` station items
  - `PACKING` reads from completed `IRONING` station items
- this PR only covers worker order detail retrieval and does not implement station processing yet
