### PR TITLE
get worker history

### DIFF
--- a/src/features/bypass-requests/bypass-request-controller.ts
+++ b/src/features/bypass-requests/bypass-request-controller.ts
@@ -5,8 +5,50 @@ import { Validation } from '@/validations/validation';
 import { BypassRequestValidation } from '@/validations/bypass-request-validation';
 import { UserRequest } from '@/types/user-request';
 import type { StationType } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
 
 export class BypassRequestController {
+  static async createWorker(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const station = req.staff?.workerType;
+
+      if (!station) {
+        throw new ResponseError(
+          422,
+          'Worker station or outlet assignment is not configured',
+        );
+      }
+
+      const orderId = Validation.validate(
+        BypassRequestValidation.ID_PARAM,
+        req.params.id,
+      );
+      const request = Validation.validate(
+        BypassRequestValidation.CREATE,
+        req.body,
+      );
+
+      const result = await BypassRequestService.create(
+        req.staff!.id,
+        orderId,
+        station,
+        request,
+      );
+
+      res.status(201).json({
+        status: 'success',
+        message: 'Bypass request submitted. Awaiting admin approval.',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
   static async create(req: UserRequest, res: Response, next: NextFunction) {
     try {
       const station = Validation.validate(

--- a/src/features/bypass-requests/bypass-request-model.ts
+++ b/src/features/bypass-requests/bypass-request-model.ts
@@ -8,6 +8,7 @@ export type BypassItemInput = {
 
 export type CreateBypassRequestInput = {
   items: BypassItemInput[];
+  notes?: string;
 };
 
 export type ApproveBypassInput = {

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -58,7 +58,13 @@ export class BypassRequestService {
       await assertNoPendingBypass(tx, sr.id);
       await saveStationItems(tx, sr.id, data.items);
       const bypass = await tx.bypassRequest.create({
-        data: { stationRecordId: sr.id, workerId, adminId: null, status: BypassStatus.PENDING, problemDescription: null },
+        data: {
+          stationRecordId: sr.id,
+          workerId,
+          adminId: null,
+          status: BypassStatus.PENDING,
+          problemDescription: data.notes ?? null,
+        },
       });
       await tx.stationRecord.update({ where: { id: sr.id }, data: { status: StationStatus.BYPASS_REQUESTED } });
       return toBypassCreateResponse(bypass);

--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -20,4 +20,29 @@ export class WorkerOrderController {
       next(error);
     }
   }
+
+  static async getOrderDetail(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const orderId = Validation.validate(
+        WorkerOrderValidation.ID_PARAM,
+        req.params.id,
+      );
+      const result = await WorkerOrderService.getWorkerOrderDetail(
+        req.staff!,
+        orderId,
+      );
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker order retrieved',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -45,4 +45,34 @@ export class WorkerOrderController {
       next(error);
     }
   }
+
+  static async processOrder(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const orderId = Validation.validate(
+        WorkerOrderValidation.ID_PARAM,
+        req.params.id,
+      );
+      const request = Validation.validate(
+        WorkerOrderValidation.PROCESS,
+        req.body,
+      );
+      const result = await WorkerOrderService.processWorkerOrder(
+        req.staff!,
+        orderId,
+        request,
+      );
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker order processed successfully',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/features/worker-orders/worker-order-controller.ts
+++ b/src/features/worker-orders/worker-order-controller.ts
@@ -5,6 +5,26 @@ import { UserRequest } from '@/types/user-request';
 import { WorkerOrderService } from './worker-order-service';
 
 export class WorkerOrderController {
+  static async getHistory(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const query = Validation.validate(WorkerOrderValidation.HISTORY, req.query);
+      const result = await WorkerOrderService.getWorkerHistory(req.staff!, query);
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Worker history retrieved',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
   static async getOrders(req: UserRequest, res: Response, next: NextFunction) {
     try {
       const query = Validation.validate(WorkerOrderValidation.LIST, req.query);

--- a/src/features/worker-orders/worker-order-helper.ts
+++ b/src/features/worker-orders/worker-order-helper.ts
@@ -1,0 +1,142 @@
+import { prisma } from '@/application/database';
+import type { Prisma, Staff, StationType } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import {
+  type WorkerHistoryQuery,
+  type WorkerOrderListQuery,
+  type WorkerOrderProcessInput,
+} from './worker-order-model';
+import { StationStatus } from '@/features/bypass-requests/bypass-request-helpers';
+
+export const buildWorkerOrdersWhere = (
+  staff: Staff,
+  query: WorkerOrderListQuery,
+) => {
+  const where: Record<string, unknown> = {
+    station: staff.workerType,
+    order: { outletId: staff.outletId },
+  };
+
+  if (query.status) where.status = query.status;
+
+  if (query.date) {
+    const startOfDay = new Date(`${query.date}T00:00:00.000Z`);
+    const endOfDay = new Date(`${query.date}T23:59:59.999Z`);
+
+    where.createdAt = {
+      gte: startOfDay,
+      lte: endOfDay,
+    };
+  }
+
+  return where;
+};
+
+export const buildWorkerHistoryWhere = (
+  staff: Staff,
+  query: WorkerHistoryQuery,
+) => {
+  const where: Record<string, unknown> = {
+    staffId: staff.id,
+    status: StationStatus.COMPLETED,
+    order: { outletId: staff.outletId },
+  };
+
+  if (query.station) where.station = query.station;
+
+  if (query.date) {
+    const startOfDay = new Date(`${query.date}T00:00:00.000Z`);
+    const endOfDay = new Date(`${query.date}T23:59:59.999Z`);
+
+    where.completedAt = {
+      gte: startOfDay,
+      lte: endOfDay,
+    };
+  }
+
+  return where;
+};
+
+export const getWorkerQueueContext = (staff: Staff) => {
+  if (!staff.outletId || !staff.workerType) {
+    throw new ResponseError(
+      422,
+      'Worker station or outlet assignment is not configured',
+    );
+  }
+
+  return {
+    outletId: staff.outletId,
+    workerType: staff.workerType,
+  };
+};
+
+export const assertQuantitiesMatch = (
+  reference: Array<{ laundryItemId: string; quantity: number }>,
+  submitted: WorkerOrderProcessInput['items'],
+) => {
+  const referenceMap = new Map(
+    reference.map((item) => [item.laundryItemId, item.quantity]),
+  );
+  const submittedMap = new Map(
+    submitted.map((item) => [item.laundryItemId, item.quantity]),
+  );
+  const isMatch =
+    referenceMap.size === submittedMap.size &&
+    [...referenceMap].every(
+      ([id, quantity]) => submittedMap.get(id) === quantity,
+    );
+
+  if (!isMatch) {
+    throw new ResponseError(400, 'Quantity mismatch detected');
+  }
+};
+
+export const loadWorkerStationRecordForProcess = async (
+  tx: Prisma.TransactionClient,
+  orderId: string,
+  station: StationType,
+  workerId: string,
+) => {
+  const stationRecord = await tx.stationRecord.findUnique({
+    where: { orderId_station: { orderId, station } },
+    include: {
+      order: true,
+      stationItems: true,
+    },
+  });
+
+  if (!stationRecord) {
+    throw new ResponseError(404, 'Station record not found');
+  }
+
+  if (stationRecord.staffId !== workerId) {
+    throw new ResponseError(403, 'You are not assigned to this station');
+  }
+
+  return stationRecord;
+};
+
+export const findNextStationWorker = async (
+  outletId: string,
+  station: StationType,
+) => {
+  const worker = await prisma.staff.findFirst({
+    where: {
+      role: 'WORKER',
+      isActive: true,
+      outletId,
+      workerType: station,
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (!worker) {
+    throw new ResponseError(
+      422,
+      `No active worker configured for ${station} station`,
+    );
+  }
+
+  return worker;
+};

--- a/src/features/worker-orders/worker-order-mapper.ts
+++ b/src/features/worker-orders/worker-order-mapper.ts
@@ -1,0 +1,149 @@
+import type {
+  OrderStatus,
+  Prisma,
+  StationStatus,
+  StationType,
+} from '@/generated/prisma/client';
+import type {
+  WorkerHistoryResponse,
+  WorkerOrderDetailResponse,
+  WorkerOrderItemResponse,
+  WorkerOrderProcessResponse,
+  WorkerOrderResponse,
+} from './worker-order-model';
+
+type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+type WorkerOrderDetailRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    stationItems: {
+      include: {
+        laundryItem: {
+          select: {
+            name: true;
+          };
+        };
+      };
+    };
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+const getPreviousStation = (station: StationType): StationType | null => {
+  if (station === 'WASHING') return null;
+  if (station === 'IRONING') return 'WASHING';
+  return 'IRONING';
+};
+
+const toWorkerOrderItemResponse = (
+  item: { laundryItemId: string; quantity: number; laundryItem: { name: string } },
+): WorkerOrderItemResponse => ({
+  laundryItemId: item.laundryItemId,
+  itemName: item.laundryItem.name,
+  quantity: item.quantity,
+});
+
+export const toWorkerOrderResponse = (
+  record: WorkerOrderRecord,
+): WorkerOrderResponse => ({
+  id: record.id,
+  orderId: record.orderId,
+  station: record.station,
+  status: record.status,
+  totalItems: record.order.items.reduce((total, item) => total + item.quantity, 0),
+  updatedAt: record.order.updatedAt,
+  createdAt: record.createdAt,
+  customerName: record.order.pickupRequest.customerUser.name ?? null,
+  outletName: record.order.outlet.name,
+});
+
+export const toWorkerHistoryResponse = (
+  record: WorkerOrderRecord,
+): WorkerHistoryResponse => {
+  if (!record.completedAt) {
+    throw new Error(
+      'Invariant: completedAt must be set when returning worker history',
+    );
+  }
+
+  return {
+    ...toWorkerOrderResponse(record),
+    completedAt: record.completedAt,
+  };
+};
+
+export const toWorkerOrderDetailResponse = (
+  record: WorkerOrderDetailRecord,
+  referenceItems: WorkerOrderItemResponse[],
+): WorkerOrderDetailResponse => ({
+  orderId: record.orderId,
+  stationRecordId: record.id,
+  station: record.station,
+  previousStation: getPreviousStation(record.station),
+  stationStatus: record.status,
+  orderStatus: record.order.status,
+  paymentStatus: record.order.paymentStatus,
+  totalItems: record.order.items.reduce((total, item) => total + item.quantity, 0),
+  customerName: record.order.pickupRequest.customerUser.name ?? null,
+  outletName: record.order.outlet.name,
+  createdAt: record.createdAt,
+  updatedAt: record.order.updatedAt,
+  referenceItems,
+  stationItems: record.stationItems.map(toWorkerOrderItemResponse),
+});
+
+export const toWorkerOrderProcessResponse = (
+  record: {
+    id: string;
+    orderId: string;
+    station: StationType;
+    status: StationStatus;
+    completedAt: Date | null;
+  },
+  orderStatus: OrderStatus,
+): WorkerOrderProcessResponse => {
+  if (!record.completedAt) {
+    throw new Error('Invariant: completedAt must be set when processing succeeds');
+  }
+
+  return {
+    orderId: record.orderId,
+    stationRecordId: record.id,
+    station: record.station,
+    stationStatus: record.status,
+    orderStatus,
+    completedAt: record.completedAt,
+  };
+};

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -1,4 +1,11 @@
-import type { Prisma, Staff, StationStatus, StationType } from '@/generated/prisma/client';
+import type {
+  OrderPaymentStatus,
+  OrderStatus,
+  Prisma,
+  Staff,
+  StationStatus,
+  StationType,
+} from '@/generated/prisma/client';
 
 export type WorkerOrderListQuery = {
   page: number;
@@ -17,6 +24,29 @@ export type WorkerOrderResponse = {
   createdAt: Date;
   customerName: string | null;
   outletName: string;
+};
+
+export type WorkerOrderItemResponse = {
+  laundryItemId: string;
+  itemName: string;
+  quantity: number;
+};
+
+export type WorkerOrderDetailResponse = {
+  orderId: string;
+  stationRecordId: string;
+  station: StationType;
+  previousStation: StationType | null;
+  stationStatus: StationStatus;
+  orderStatus: OrderStatus;
+  paymentStatus: OrderPaymentStatus;
+  totalItems: number;
+  customerName: string | null;
+  outletName: string;
+  createdAt: Date;
+  updatedAt: Date;
+  referenceItems: WorkerOrderItemResponse[];
+  stationItems: WorkerOrderItemResponse[];
 };
 
 export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
@@ -41,6 +71,49 @@ type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
   };
 }>;
 
+type WorkerOrderDetailRecord = Prisma.StationRecordGetPayload<{
+  include: {
+    stationItems: {
+      include: {
+        laundryItem: {
+          select: {
+            name: true;
+          };
+        };
+      };
+    };
+    order: {
+      include: {
+        outlet: true;
+        pickupRequest: {
+          include: {
+            customerUser: {
+              select: {
+                name: true;
+              };
+            };
+          };
+        };
+        items: true;
+      };
+    };
+  };
+}>;
+
+const getPreviousStation = (station: StationType): StationType | null => {
+  if (station === 'WASHING') return null;
+  if (station === 'IRONING') return 'WASHING';
+  return 'IRONING';
+};
+
+const toWorkerOrderItemResponse = (
+  item: { laundryItemId: string; quantity: number; laundryItem: { name: string } },
+): WorkerOrderItemResponse => ({
+  laundryItemId: item.laundryItemId,
+  itemName: item.laundryItem.name,
+  quantity: item.quantity,
+});
+
 export function toWorkerOrderResponse(
   record: WorkerOrderRecord,
 ): WorkerOrderResponse {
@@ -57,5 +130,30 @@ export function toWorkerOrderResponse(
     createdAt: record.createdAt,
     customerName: record.order.pickupRequest.customerUser.name ?? null,
     outletName: record.order.outlet.name,
+  };
+}
+
+export function toWorkerOrderDetailResponse(
+  record: WorkerOrderDetailRecord,
+  referenceItems: WorkerOrderItemResponse[],
+): WorkerOrderDetailResponse {
+  return {
+    orderId: record.orderId,
+    stationRecordId: record.id,
+    station: record.station,
+    previousStation: getPreviousStation(record.station),
+    stationStatus: record.status,
+    orderStatus: record.order.status,
+    paymentStatus: record.order.paymentStatus,
+    totalItems: record.order.items.reduce(
+      (total, item) => total + item.quantity,
+      0,
+    ),
+    customerName: record.order.pickupRequest.customerUser.name ?? null,
+    outletName: record.order.outlet.name,
+    createdAt: record.createdAt,
+    updatedAt: record.order.updatedAt,
+    referenceItems,
+    stationItems: record.stationItems.map(toWorkerOrderItemResponse),
   };
 }

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -14,6 +14,15 @@ export type WorkerOrderListQuery = {
   date?: string;
 };
 
+export type WorkerOrderProcessItemInput = {
+  laundryItemId: string;
+  quantity: number;
+};
+
+export type WorkerOrderProcessInput = {
+  items: WorkerOrderProcessItemInput[];
+};
+
 export type WorkerOrderResponse = {
   id: string;
   orderId: string;
@@ -47,6 +56,15 @@ export type WorkerOrderDetailResponse = {
   updatedAt: Date;
   referenceItems: WorkerOrderItemResponse[];
   stationItems: WorkerOrderItemResponse[];
+};
+
+export type WorkerOrderProcessResponse = {
+  orderId: string;
+  stationRecordId: string;
+  station: StationType;
+  stationStatus: StationStatus;
+  orderStatus: OrderStatus;
+  completedAt: Date;
 };
 
 export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
@@ -155,5 +173,29 @@ export function toWorkerOrderDetailResponse(
     updatedAt: record.order.updatedAt,
     referenceItems,
     stationItems: record.stationItems.map(toWorkerOrderItemResponse),
+  };
+}
+
+export function toWorkerOrderProcessResponse(
+  record: {
+    id: string;
+    orderId: string;
+    station: StationType;
+    status: StationStatus;
+    completedAt: Date | null;
+  },
+  orderStatus: OrderStatus,
+): WorkerOrderProcessResponse {
+  if (!record.completedAt) {
+    throw new Error('Invariant: completedAt must be set when processing succeeds');
+  }
+
+  return {
+    orderId: record.orderId,
+    stationRecordId: record.id,
+    station: record.station,
+    stationStatus: record.status,
+    orderStatus,
+    completedAt: record.completedAt,
   };
 }

--- a/src/features/worker-orders/worker-order-model.ts
+++ b/src/features/worker-orders/worker-order-model.ts
@@ -1,7 +1,6 @@
 import type {
   OrderPaymentStatus,
   OrderStatus,
-  Prisma,
   Staff,
   StationStatus,
   StationType,
@@ -11,6 +10,13 @@ export type WorkerOrderListQuery = {
   page: number;
   limit: number;
   status?: StationStatus;
+  date?: string;
+};
+
+export type WorkerHistoryQuery = {
+  page: number;
+  limit: number;
+  station?: StationType;
   date?: string;
 };
 
@@ -33,6 +39,10 @@ export type WorkerOrderResponse = {
   createdAt: Date;
   customerName: string | null;
   outletName: string;
+};
+
+export type WorkerHistoryResponse = WorkerOrderResponse & {
+  completedAt: Date;
 };
 
 export type WorkerOrderItemResponse = {
@@ -68,134 +78,3 @@ export type WorkerOrderProcessResponse = {
 };
 
 export type WorkerQueueContext = Pick<Staff, 'id' | 'outletId' | 'workerType'>;
-
-type WorkerOrderRecord = Prisma.StationRecordGetPayload<{
-  include: {
-    order: {
-      include: {
-        outlet: true;
-        pickupRequest: {
-          include: {
-            customerUser: {
-              select: {
-                name: true;
-              };
-            };
-          };
-        };
-        items: true;
-      };
-    };
-  };
-}>;
-
-type WorkerOrderDetailRecord = Prisma.StationRecordGetPayload<{
-  include: {
-    stationItems: {
-      include: {
-        laundryItem: {
-          select: {
-            name: true;
-          };
-        };
-      };
-    };
-    order: {
-      include: {
-        outlet: true;
-        pickupRequest: {
-          include: {
-            customerUser: {
-              select: {
-                name: true;
-              };
-            };
-          };
-        };
-        items: true;
-      };
-    };
-  };
-}>;
-
-const getPreviousStation = (station: StationType): StationType | null => {
-  if (station === 'WASHING') return null;
-  if (station === 'IRONING') return 'WASHING';
-  return 'IRONING';
-};
-
-const toWorkerOrderItemResponse = (
-  item: { laundryItemId: string; quantity: number; laundryItem: { name: string } },
-): WorkerOrderItemResponse => ({
-  laundryItemId: item.laundryItemId,
-  itemName: item.laundryItem.name,
-  quantity: item.quantity,
-});
-
-export function toWorkerOrderResponse(
-  record: WorkerOrderRecord,
-): WorkerOrderResponse {
-  return {
-    id: record.id,
-    orderId: record.orderId,
-    station: record.station,
-    status: record.status,
-    totalItems: record.order.items.reduce(
-      (total, item) => total + item.quantity,
-      0,
-    ),
-    updatedAt: record.order.updatedAt,
-    createdAt: record.createdAt,
-    customerName: record.order.pickupRequest.customerUser.name ?? null,
-    outletName: record.order.outlet.name,
-  };
-}
-
-export function toWorkerOrderDetailResponse(
-  record: WorkerOrderDetailRecord,
-  referenceItems: WorkerOrderItemResponse[],
-): WorkerOrderDetailResponse {
-  return {
-    orderId: record.orderId,
-    stationRecordId: record.id,
-    station: record.station,
-    previousStation: getPreviousStation(record.station),
-    stationStatus: record.status,
-    orderStatus: record.order.status,
-    paymentStatus: record.order.paymentStatus,
-    totalItems: record.order.items.reduce(
-      (total, item) => total + item.quantity,
-      0,
-    ),
-    customerName: record.order.pickupRequest.customerUser.name ?? null,
-    outletName: record.order.outlet.name,
-    createdAt: record.createdAt,
-    updatedAt: record.order.updatedAt,
-    referenceItems,
-    stationItems: record.stationItems.map(toWorkerOrderItemResponse),
-  };
-}
-
-export function toWorkerOrderProcessResponse(
-  record: {
-    id: string;
-    orderId: string;
-    station: StationType;
-    status: StationStatus;
-    completedAt: Date | null;
-  },
-  orderStatus: OrderStatus,
-): WorkerOrderProcessResponse {
-  if (!record.completedAt) {
-    throw new Error('Invariant: completedAt must be set when processing succeeds');
-  }
-
-  return {
-    orderId: record.orderId,
-    stationRecordId: record.id,
-    station: record.station,
-    stationStatus: record.status,
-    orderStatus,
-    completedAt: record.completedAt,
-  };
-}

--- a/src/features/worker-orders/worker-order-query.ts
+++ b/src/features/worker-orders/worker-order-query.ts
@@ -1,0 +1,151 @@
+import { prisma } from '@/application/database';
+import type { Staff } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import { fetchReferenceItems } from '@/features/bypass-requests/bypass-request-helpers';
+import {
+  toWorkerHistoryResponse,
+  toWorkerOrderDetailResponse,
+  toWorkerOrderResponse,
+} from './worker-order-mapper';
+import type {
+  WorkerHistoryQuery,
+  WorkerOrderListQuery,
+} from './worker-order-model';
+import {
+  buildWorkerHistoryWhere,
+  buildWorkerOrdersWhere,
+  getWorkerQueueContext,
+} from './worker-order-helper';
+
+export const getWorkerOrders = async (
+  staff: Staff,
+  query: WorkerOrderListQuery,
+) => {
+  const queueContext = getWorkerQueueContext(staff);
+  const skip = (query.page - 1) * query.limit;
+  const where = buildWorkerOrdersWhere({ ...staff, ...queueContext }, query);
+
+  const [records, total] = await Promise.all([
+    prisma.stationRecord.findMany({
+      where,
+      skip,
+      take: query.limit,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    }),
+    prisma.stationRecord.count({ where }),
+  ]);
+
+  return {
+    data: records.map(toWorkerOrderResponse),
+    meta: {
+      page: query.page,
+      limit: query.limit,
+      total,
+      totalPages: Math.ceil(total / query.limit),
+    },
+  };
+};
+
+export const getWorkerOrderDetail = async (staff: Staff, orderId: string) => {
+  const queueContext = getWorkerQueueContext(staff);
+
+  const record = await prisma.stationRecord.findFirst({
+    where: {
+      orderId,
+      station: queueContext.workerType,
+      order: { outletId: queueContext.outletId },
+    },
+    include: {
+      stationItems: {
+        include: {
+          laundryItem: {
+            select: { name: true },
+          },
+        },
+      },
+      order: {
+        include: {
+          outlet: true,
+          pickupRequest: {
+            include: {
+              customerUser: {
+                select: { name: true },
+              },
+            },
+          },
+          items: true,
+        },
+      },
+    },
+  });
+
+  if (!record) {
+    throw new ResponseError(404, 'Worker order not found');
+  }
+
+  const referenceItems = await fetchReferenceItems(orderId, record.station);
+
+  return toWorkerOrderDetailResponse(
+    record as Parameters<typeof toWorkerOrderDetailResponse>[0],
+    referenceItems,
+  );
+};
+
+export const getWorkerHistory = async (
+  staff: Staff,
+  query: WorkerHistoryQuery,
+) => {
+  const queueContext = getWorkerQueueContext(staff);
+  const skip = (query.page - 1) * query.limit;
+  const where = buildWorkerHistoryWhere({ ...staff, ...queueContext }, query);
+
+  const [records, total] = await Promise.all([
+    prisma.stationRecord.findMany({
+      where,
+      skip,
+      take: query.limit,
+      orderBy: { completedAt: 'desc' },
+      include: {
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    }),
+    prisma.stationRecord.count({ where }),
+  ]);
+
+  return {
+    data: records.map(toWorkerHistoryResponse),
+    meta: {
+      page: query.page,
+      limit: query.limit,
+      total,
+      totalPages: Math.ceil(total / query.limit),
+    },
+  };
+};

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,7 +1,9 @@
 import { prisma } from '@/application/database';
 import type { Staff } from '@/generated/prisma/client';
 import { ResponseError } from '@/error/response-error';
+import { fetchReferenceItems } from '@/features/bypass-requests/bypass-request-helpers';
 import {
+  toWorkerOrderDetailResponse,
   type WorkerOrderListQuery,
   toWorkerOrderResponse,
 } from './worker-order-model';
@@ -27,21 +29,29 @@ const buildWorkerOrdersWhere = (staff: Staff, query: WorkerOrderListQuery) => {
   return where;
 };
 
-const assertWorkerQueueContext = (staff: Staff) => {
+const getWorkerQueueContext = (staff: Staff) => {
   if (!staff.outletId || !staff.workerType) {
     throw new ResponseError(
       422,
       'Worker station or outlet assignment is not configured',
     );
   }
+
+  return {
+    outletId: staff.outletId,
+    workerType: staff.workerType,
+  };
 };
 
 export class WorkerOrderService {
   static async getWorkerOrders(staff: Staff, query: WorkerOrderListQuery) {
-    assertWorkerQueueContext(staff);
+    const queueContext = getWorkerQueueContext(staff);
 
     const skip = (query.page - 1) * query.limit;
-    const where = buildWorkerOrdersWhere(staff, query);
+    const where = buildWorkerOrdersWhere(
+      { ...staff, ...queueContext },
+      query,
+    );
 
     const [records, total] = await Promise.all([
       prisma.stationRecord.findMany({
@@ -77,5 +87,50 @@ export class WorkerOrderService {
         totalPages: Math.ceil(total / query.limit),
       },
     };
+  }
+
+  static async getWorkerOrderDetail(staff: Staff, orderId: string) {
+    const queueContext = getWorkerQueueContext(staff);
+
+    const record = await prisma.stationRecord.findFirst({
+      where: {
+        orderId,
+        station: queueContext.workerType,
+        order: { outletId: queueContext.outletId },
+      },
+      include: {
+        stationItems: {
+          include: {
+            laundryItem: {
+              select: { name: true },
+            },
+          },
+        },
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    });
+
+    if (!record) {
+      throw new ResponseError(404, 'Worker order not found');
+    }
+
+    const referenceItems = await fetchReferenceItems(orderId, record.station);
+
+    return toWorkerOrderDetailResponse(
+      record as Parameters<typeof toWorkerOrderDetailResponse>[0],
+      referenceItems,
+    );
   }
 }

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,215 +1,43 @@
 import { prisma } from '@/application/database';
-import type { Prisma, Staff, StationType } from '@/generated/prisma/client';
+import type { Staff } from '@/generated/prisma/client';
 import { ResponseError } from '@/error/response-error';
 import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 import { resolveStationFromOrderStatus } from '@/features/worker-notifications/worker-notification-model';
 import {
   advanceOrderStatus,
-  fetchReferenceItems,
   fetchReferenceQuantities,
   saveStationItems,
   StationStatus,
 } from '@/features/bypass-requests/bypass-request-helpers';
 import {
-  toWorkerOrderDetailResponse,
+  type WorkerHistoryQuery,
   type WorkerOrderListQuery,
   type WorkerOrderProcessInput,
-  toWorkerOrderProcessResponse,
-  toWorkerOrderResponse,
 } from './worker-order-model';
-
-const buildWorkerOrdersWhere = (staff: Staff, query: WorkerOrderListQuery) => {
-  const where: Record<string, unknown> = {
-    station: staff.workerType,
-    order: { outletId: staff.outletId },
-  };
-
-  if (query.status) where.status = query.status;
-
-  if (query.date) {
-    const startOfDay = new Date(`${query.date}T00:00:00.000Z`);
-    const endOfDay = new Date(`${query.date}T23:59:59.999Z`);
-
-    where.createdAt = {
-      gte: startOfDay,
-      lte: endOfDay,
-    };
-  }
-
-  return where;
-};
-
-const getWorkerQueueContext = (staff: Staff) => {
-  if (!staff.outletId || !staff.workerType) {
-    throw new ResponseError(
-      422,
-      'Worker station or outlet assignment is not configured',
-    );
-  }
-
-  return {
-    outletId: staff.outletId,
-    workerType: staff.workerType,
-  };
-};
-
-const assertQuantitiesMatch = (
-  reference: Array<{ laundryItemId: string; quantity: number }>,
-  submitted: WorkerOrderProcessInput['items'],
-) => {
-  const referenceMap = new Map(
-    reference.map((item) => [item.laundryItemId, item.quantity]),
-  );
-  const submittedMap = new Map(
-    submitted.map((item) => [item.laundryItemId, item.quantity]),
-  );
-  const isMatch =
-    referenceMap.size === submittedMap.size &&
-    [...referenceMap].every(([id, quantity]) => submittedMap.get(id) === quantity);
-
-  if (!isMatch) {
-    throw new ResponseError(400, 'Quantity mismatch detected');
-  }
-};
-
-const loadWorkerStationRecordForProcess = async (
-  tx: Prisma.TransactionClient,
-  orderId: string,
-  station: StationType,
-  workerId: string,
-) => {
-  const stationRecord = await tx.stationRecord.findUnique({
-    where: { orderId_station: { orderId, station } },
-    include: {
-      order: true,
-      stationItems: true,
-    },
-  });
-
-  if (!stationRecord) {
-    throw new ResponseError(404, 'Station record not found');
-  }
-
-  if (stationRecord.staffId !== workerId) {
-    throw new ResponseError(403, 'You are not assigned to this station');
-  }
-
-  return stationRecord;
-};
-
-const findNextStationWorker = async (
-  outletId: string,
-  station: StationType,
-) => {
-  const worker = await prisma.staff.findFirst({
-    where: {
-      role: 'WORKER',
-      isActive: true,
-      outletId,
-      workerType: station,
-    },
-    orderBy: { createdAt: 'asc' },
-  });
-
-  if (!worker) {
-    throw new ResponseError(
-      422,
-      `No active worker configured for ${station} station`,
-    );
-  }
-
-  return worker;
-};
+import {
+  assertQuantitiesMatch,
+  findNextStationWorker,
+  getWorkerQueueContext,
+  loadWorkerStationRecordForProcess,
+} from './worker-order-helper';
+import { toWorkerOrderProcessResponse } from './worker-order-mapper';
+import {
+  getWorkerHistory,
+  getWorkerOrderDetail,
+  getWorkerOrders,
+} from './worker-order-query';
 
 export class WorkerOrderService {
   static async getWorkerOrders(staff: Staff, query: WorkerOrderListQuery) {
-    const queueContext = getWorkerQueueContext(staff);
-
-    const skip = (query.page - 1) * query.limit;
-    const where = buildWorkerOrdersWhere(
-      { ...staff, ...queueContext },
-      query,
-    );
-
-    const [records, total] = await Promise.all([
-      prisma.stationRecord.findMany({
-        where,
-        skip,
-        take: query.limit,
-        orderBy: { createdAt: 'desc' },
-        include: {
-          order: {
-            include: {
-              outlet: true,
-              pickupRequest: {
-                include: {
-                  customerUser: {
-                    select: { name: true },
-                  },
-                },
-              },
-              items: true,
-            },
-          },
-        },
-      }),
-      prisma.stationRecord.count({ where }),
-    ]);
-
-    return {
-      data: records.map(toWorkerOrderResponse),
-      meta: {
-        page: query.page,
-        limit: query.limit,
-        total,
-        totalPages: Math.ceil(total / query.limit),
-      },
-    };
+    return getWorkerOrders(staff, query);
   }
 
   static async getWorkerOrderDetail(staff: Staff, orderId: string) {
-    const queueContext = getWorkerQueueContext(staff);
+    return getWorkerOrderDetail(staff, orderId);
+  }
 
-    const record = await prisma.stationRecord.findFirst({
-      where: {
-        orderId,
-        station: queueContext.workerType,
-        order: { outletId: queueContext.outletId },
-      },
-      include: {
-        stationItems: {
-          include: {
-            laundryItem: {
-              select: { name: true },
-            },
-          },
-        },
-        order: {
-          include: {
-            outlet: true,
-            pickupRequest: {
-              include: {
-                customerUser: {
-                  select: { name: true },
-                },
-              },
-            },
-            items: true,
-          },
-        },
-      },
-    });
-
-    if (!record) {
-      throw new ResponseError(404, 'Worker order not found');
-    }
-
-    const referenceItems = await fetchReferenceItems(orderId, record.station);
-
-    return toWorkerOrderDetailResponse(
-      record as Parameters<typeof toWorkerOrderDetailResponse>[0],
-      referenceItems,
-    );
+  static async getWorkerHistory(staff: Staff, query: WorkerHistoryQuery) {
+    return getWorkerHistory(staff, query);
   }
 
   static async processWorkerOrder(

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -72,12 +72,6 @@ const assertQuantitiesMatch = (
   }
 };
 
-const assertProcessableStation = (station: StationType) => {
-  if (station === 'PACKING') {
-    throw new ResponseError(422, 'Packing completion is handled separately');
-  }
-};
-
 const loadWorkerStationRecordForProcess = async (
   tx: Prisma.TransactionClient,
   orderId: string,
@@ -224,7 +218,6 @@ export class WorkerOrderService {
     data: WorkerOrderProcessInput,
   ) {
     const queueContext = getWorkerQueueContext(staff);
-    assertProcessableStation(queueContext.workerType);
 
     const result = await prisma.$transaction(async (tx) => {
       const stationRecord = await loadWorkerStationRecordForProcess(

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -1,10 +1,20 @@
 import { prisma } from '@/application/database';
-import type { Staff } from '@/generated/prisma/client';
+import type { Prisma, Staff, StationType } from '@/generated/prisma/client';
 import { ResponseError } from '@/error/response-error';
-import { fetchReferenceItems } from '@/features/bypass-requests/bypass-request-helpers';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
+import { resolveStationFromOrderStatus } from '@/features/worker-notifications/worker-notification-model';
+import {
+  advanceOrderStatus,
+  fetchReferenceItems,
+  fetchReferenceQuantities,
+  saveStationItems,
+  StationStatus,
+} from '@/features/bypass-requests/bypass-request-helpers';
 import {
   toWorkerOrderDetailResponse,
   type WorkerOrderListQuery,
+  type WorkerOrderProcessInput,
+  toWorkerOrderProcessResponse,
   toWorkerOrderResponse,
 } from './worker-order-model';
 
@@ -41,6 +51,80 @@ const getWorkerQueueContext = (staff: Staff) => {
     outletId: staff.outletId,
     workerType: staff.workerType,
   };
+};
+
+const assertQuantitiesMatch = (
+  reference: Array<{ laundryItemId: string; quantity: number }>,
+  submitted: WorkerOrderProcessInput['items'],
+) => {
+  const referenceMap = new Map(
+    reference.map((item) => [item.laundryItemId, item.quantity]),
+  );
+  const submittedMap = new Map(
+    submitted.map((item) => [item.laundryItemId, item.quantity]),
+  );
+  const isMatch =
+    referenceMap.size === submittedMap.size &&
+    [...referenceMap].every(([id, quantity]) => submittedMap.get(id) === quantity);
+
+  if (!isMatch) {
+    throw new ResponseError(400, 'Quantity mismatch detected');
+  }
+};
+
+const assertProcessableStation = (station: StationType) => {
+  if (station === 'PACKING') {
+    throw new ResponseError(422, 'Packing completion is handled separately');
+  }
+};
+
+const loadWorkerStationRecordForProcess = async (
+  tx: Prisma.TransactionClient,
+  orderId: string,
+  station: StationType,
+  workerId: string,
+) => {
+  const stationRecord = await tx.stationRecord.findUnique({
+    where: { orderId_station: { orderId, station } },
+    include: {
+      order: true,
+      stationItems: true,
+    },
+  });
+
+  if (!stationRecord) {
+    throw new ResponseError(404, 'Station record not found');
+  }
+
+  if (stationRecord.staffId !== workerId) {
+    throw new ResponseError(403, 'You are not assigned to this station');
+  }
+
+  return stationRecord;
+};
+
+const findNextStationWorker = async (
+  outletId: string,
+  station: StationType,
+) => {
+  const worker = await prisma.staff.findFirst({
+    where: {
+      role: 'WORKER',
+      isActive: true,
+      outletId,
+      workerType: station,
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (!worker) {
+    throw new ResponseError(
+      422,
+      `No active worker configured for ${station} station`,
+    );
+  }
+
+  return worker;
 };
 
 export class WorkerOrderService {
@@ -132,5 +216,80 @@ export class WorkerOrderService {
       record as Parameters<typeof toWorkerOrderDetailResponse>[0],
       referenceItems,
     );
+  }
+
+  static async processWorkerOrder(
+    staff: Staff,
+    orderId: string,
+    data: WorkerOrderProcessInput,
+  ) {
+    const queueContext = getWorkerQueueContext(staff);
+    assertProcessableStation(queueContext.workerType);
+
+    const result = await prisma.$transaction(async (tx) => {
+      const stationRecord = await loadWorkerStationRecordForProcess(
+        tx,
+        orderId,
+        queueContext.workerType,
+        staff.id,
+      );
+
+      if (stationRecord.status !== StationStatus.IN_PROGRESS) {
+        throw new ResponseError(409, 'Station is not in progress');
+      }
+
+      const referenceItems = await fetchReferenceQuantities(
+        tx,
+        orderId,
+        queueContext.workerType,
+      );
+      assertQuantitiesMatch(referenceItems, data.items);
+
+      await saveStationItems(tx, stationRecord.id, data.items);
+
+      const completedRecord = await tx.stationRecord.update({
+        where: { id: stationRecord.id },
+        data: {
+          status: StationStatus.COMPLETED,
+          completedAt: new Date(),
+        },
+      });
+
+      const nextOrderStatus = await advanceOrderStatus(tx, stationRecord.order);
+      const nextStation = resolveStationFromOrderStatus(nextOrderStatus);
+
+      if (nextStation) {
+        const nextWorker = await findNextStationWorker(
+          stationRecord.order.outletId,
+          nextStation,
+        );
+
+        await tx.stationRecord.create({
+          data: {
+            orderId,
+            station: nextStation,
+            staffId: nextWorker.id,
+            status: StationStatus.IN_PROGRESS,
+          },
+        });
+      }
+
+      return {
+        orderId: stationRecord.order.id,
+        outletId: stationRecord.order.outletId,
+        response: toWorkerOrderProcessResponse(
+          completedRecord,
+          nextOrderStatus,
+        ),
+      };
+    });
+
+    WorkerNotificationService.publishOrderArrival({
+      orderId: result.orderId,
+      outletId: result.outletId,
+      orderStatus: result.response.orderStatus,
+    });
+
+    return result.response;
   }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -150,6 +150,11 @@ apiRouter.post(
 
 // WORKER
 apiRouter.get(
+  '/worker/history',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.getHistory,
+);
+apiRouter.get(
   '/worker/orders',
   requireStaffRole('WORKER'),
   WorkerOrderController.getOrders,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -155,6 +155,11 @@ apiRouter.get(
   WorkerOrderController.getOrders,
 );
 apiRouter.get(
+  '/worker/orders/:id',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.getOrderDetail,
+);
+apiRouter.get(
   '/worker/notifications/stream',
   requireStaffRole('WORKER'),
   WorkerNotificationController.stream,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -159,6 +159,11 @@ apiRouter.get(
   requireStaffRole('WORKER'),
   WorkerOrderController.getOrderDetail,
 );
+apiRouter.post(
+  '/worker/orders/:id/process',
+  requireStaffRole('WORKER'),
+  WorkerOrderController.processOrder,
+);
 apiRouter.get(
   '/worker/notifications/stream',
   requireStaffRole('WORKER'),

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -164,6 +164,11 @@ apiRouter.post(
   requireStaffRole('WORKER'),
   WorkerOrderController.processOrder,
 );
+apiRouter.post(
+  '/worker/orders/:id/bypass-request',
+  requireStaffRole('WORKER'),
+  BypassRequestController.createWorker,
+);
 apiRouter.get(
   '/worker/notifications/stream',
   requireStaffRole('WORKER'),

--- a/src/validations/bypass-request-validation.ts
+++ b/src/validations/bypass-request-validation.ts
@@ -22,6 +22,7 @@ export class BypassRequestValidation {
         })
       )
       .min(1),
+    notes: z.string().trim().min(1).max(500).optional(),
   });
 
   static readonly LIST: ZodType<BypassListQuery> = z.object({

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -2,6 +2,8 @@ import { z, ZodType } from 'zod';
 import type { WorkerOrderListQuery } from '@/features/worker-orders/worker-order-model';
 
 export class WorkerOrderValidation {
+  static readonly ID_PARAM: ZodType<string> = z.uuid();
+
   static readonly LIST: ZodType<WorkerOrderListQuery> = z.object({
     page: z.coerce.number().int().min(1).default(1),
     limit: z.coerce.number().int().min(1).max(100).default(10),

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -1,8 +1,22 @@
 import { z, ZodType } from 'zod';
-import type { WorkerOrderListQuery } from '@/features/worker-orders/worker-order-model';
+import type {
+  WorkerOrderListQuery,
+  WorkerOrderProcessInput,
+} from '@/features/worker-orders/worker-order-model';
 
 export class WorkerOrderValidation {
   static readonly ID_PARAM: ZodType<string> = z.uuid();
+
+  static readonly PROCESS: ZodType<WorkerOrderProcessInput> = z.object({
+    items: z
+      .array(
+        z.object({
+          laundryItemId: z.uuid(),
+          quantity: z.number().int().positive(),
+        }),
+      )
+      .min(1),
+  });
 
   static readonly LIST: ZodType<WorkerOrderListQuery> = z.object({
     page: z.coerce.number().int().min(1).default(1),

--- a/src/validations/worker-order-validation.ts
+++ b/src/validations/worker-order-validation.ts
@@ -1,5 +1,6 @@
 import { z, ZodType } from 'zod';
 import type {
+  WorkerHistoryQuery,
   WorkerOrderListQuery,
   WorkerOrderProcessInput,
 } from '@/features/worker-orders/worker-order-model';
@@ -22,6 +23,13 @@ export class WorkerOrderValidation {
     page: z.coerce.number().int().min(1).default(1),
     limit: z.coerce.number().int().min(1).max(100).default(10),
     status: z.enum(['IN_PROGRESS', 'BYPASS_REQUESTED', 'COMPLETED']).optional(),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format').optional(),
+  });
+
+  static readonly HISTORY: ZodType<WorkerHistoryQuery> = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    station: z.enum(['WASHING', 'IRONING', 'PACKING']).optional(),
     date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format').optional(),
   });
 }

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -244,6 +244,96 @@ describe('Bypass Routes Integration Tests', () => {
     });
   });
 
+  describe('POST /api/v1/worker/orders/:id/bypass-request', () => {
+    it('returns 401 when not authenticated', async () => {
+      (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(app)
+        .post(`/api/v1/worker/orders/${VALID_UUID}/bypass-request`)
+        .send({ items: [{ laundryItemId: VALID_UUID, quantity: 5 }] });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('returns 422 when worker station is not configured', async () => {
+      mockAuthenticatedWorker();
+      (prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+        id: 'staff-1',
+        role: 'WORKER',
+        isActive: true,
+        workerType: null,
+      });
+
+      const response = await request(app)
+        .post(`/api/v1/worker/orders/${VALID_UUID}/bypass-request`)
+        .send({ items: [{ laundryItemId: VALID_UUID, quantity: 3 }] });
+
+      expect(response.status).toBe(422);
+      expect(response.body.errors).toBe(
+        'Worker station or outlet assignment is not configured',
+      );
+    });
+
+    it('returns 201 with proper envelope on valid mismatch', async () => {
+      mockAuthenticatedWorker('user-1', 'staff-1');
+      const stationRecordId = 'sr-1';
+      const bypassId = 'bp-worker-1';
+
+      (prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+        id: 'staff-1',
+        role: 'WORKER',
+        isActive: true,
+        workerType: 'WASHING',
+      });
+      (prisma.stationRecord as any).findUnique.mockResolvedValue({
+        id: stationRecordId,
+        orderId: VALID_UUID,
+        station: 'WASHING',
+        staffId: 'staff-1',
+        status: 'IN_PROGRESS',
+        stationItems: [],
+      });
+      (prisma.orderItem as any).findMany.mockResolvedValue([
+        { laundryItemId: VALID_UUID, quantity: 5 },
+      ]);
+      (prisma.bypassRequest as any).findFirst.mockResolvedValue(null);
+      (prisma.stationItem as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.stationItem as any).createMany.mockResolvedValue({ count: 1 });
+
+      const now = new Date();
+      (prisma.bypassRequest as any).create.mockResolvedValue({
+        id: bypassId,
+        stationRecordId,
+        workerId: 'staff-1',
+        adminId: null,
+        problemDescription: null,
+        status: 'PENDING',
+        createdAt: now,
+      });
+      (prisma.stationRecord as any).update.mockResolvedValue({
+        id: stationRecordId,
+        status: 'BYPASS_REQUESTED',
+      });
+
+      const response = await request(app)
+        .post(`/api/v1/worker/orders/${VALID_UUID}/bypass-request`)
+        .send({
+          items: [{ laundryItemId: VALID_UUID, quantity: 3 }],
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({
+        status: 'success',
+        message: 'Bypass request submitted. Awaiting admin approval.',
+        data: {
+          id: bypassId,
+          status: 'PENDING',
+          createdAt: now.toISOString(),
+        },
+      });
+    });
+  });
+
   describe('GET /api/v1/bypass-requests', () => {
     const makeBypassRecord = () => ({
       id: 'bp-1',

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -278,6 +278,7 @@ describe('Bypass Routes Integration Tests', () => {
       mockAuthenticatedWorker('user-1', 'staff-1');
       const stationRecordId = 'sr-1';
       const bypassId = 'bp-worker-1';
+      const notes = 'Mismatch found during washing recount.';
 
       (prisma.staff.findUnique as jest.Mock).mockResolvedValue({
         id: 'staff-1',
@@ -306,7 +307,7 @@ describe('Bypass Routes Integration Tests', () => {
         stationRecordId,
         workerId: 'staff-1',
         adminId: null,
-        problemDescription: null,
+        problemDescription: notes,
         status: 'PENDING',
         createdAt: now,
       });
@@ -319,9 +320,19 @@ describe('Bypass Routes Integration Tests', () => {
         .post(`/api/v1/worker/orders/${VALID_UUID}/bypass-request`)
         .send({
           items: [{ laundryItemId: VALID_UUID, quantity: 3 }],
+          notes,
         });
 
       expect(response.status).toBe(201);
+      expect((prisma.bypassRequest as any).create).toHaveBeenCalledWith({
+        data: {
+          stationRecordId,
+          workerId: 'staff-1',
+          adminId: null,
+          status: 'PENDING',
+          problemDescription: notes,
+        },
+      });
       expect(response.body).toEqual({
         status: 'success',
         message: 'Bypass request submitted. Awaiting admin approval.',

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -145,6 +145,67 @@ describe('Worker Order Routes', () => {
     });
   });
 
+  it('returns paginated worker history with standard envelope', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-history-1',
+        orderId: 'order-history-1',
+        station: 'WASHING',
+        status: 'COMPLETED',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        completedAt: new Date('2026-04-17T11:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const response = await request(app)
+      .get('/api/v1/worker/history')
+      .query({ page: 1, limit: 10, station: 'WASHING', date: '2026-04-17' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker history retrieved',
+      data: [
+        {
+          id: 'station-record-history-1',
+          orderId: 'order-history-1',
+          station: 'WASHING',
+          status: 'COMPLETED',
+          totalItems: 5,
+          updatedAt: '2026-04-17T10:00:00.000Z',
+          createdAt: '2026-04-17T08:00:00.000Z',
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+          completedAt: '2026-04-17T11:00:00.000Z',
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('returns 400 for invalid worker history query params', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app)
+      .get('/api/v1/worker/history')
+      .query({ page: 0, station: 'INVALID_STATION' });
+
+    expect(response.status).toBe(400);
+  });
+
   it('returns 400 for invalid worker order id param', async () => {
     mockWorkerAuth();
 

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -7,8 +7,9 @@ jest.mock('better-auth/node', () => ({
 
 jest.mock('@/application/database', () => ({
   prisma: {
+    $transaction: jest.fn(),
     user: { findUnique: jest.fn() },
-    staff: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn(), findFirst: jest.fn() },
     stationRecord: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     orderItem: { findMany: jest.fn() },
   },
@@ -20,12 +21,20 @@ jest.mock('@/utils/auth', () => ({
   },
 }));
 
+jest.mock('@/features/worker-notifications/worker-notification-service', () => ({
+  WorkerNotificationService: {
+    publishOrderArrival: jest.fn(),
+  },
+}));
+
 import request from 'supertest';
 import { app } from '@/application/app';
 import { prisma } from '@/application/database';
 import { auth } from '@/utils/auth';
 
 describe('Worker Order Routes', () => {
+  const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -223,6 +232,133 @@ describe('Worker Order Routes', () => {
             quantity: 4,
           },
         ],
+      },
+    });
+  });
+
+  it('returns 400 for invalid process payload', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app)
+      .post('/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000/process')
+      .send({ items: [] });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when submitted quantities do not match reference items', async () => {
+    mockWorkerAuth();
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          staffId: 'staff-worker',
+          status: 'IN_PROGRESS',
+          order: {
+            id: 'order-1',
+            status: 'LAUNDRY_BEING_WASHED',
+            paymentStatus: 'UNPAID',
+            outletId: 'outlet-1',
+          },
+          stationItems: [],
+        }),
+      },
+      orderItem: {
+        findMany: jest.fn().mockResolvedValue([
+          { laundryItemId: 'item-1', quantity: 5 },
+        ]),
+      },
+      stationItem: {
+        deleteMany: jest.fn(),
+        createMany: jest.fn(),
+      },
+      order: { update: jest.fn() },
+      delivery: { create: jest.fn() },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+
+    const response = await request(app)
+      .post('/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000/process')
+      .send({
+        items: [{ laundryItemId: VALID_UUID, quantity: 3 }],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toBe('Quantity mismatch detected');
+  });
+
+  it('processes a worker order and advances it to the next station', async () => {
+    mockWorkerAuth();
+    const completedAt = new Date('2026-04-18T02:00:00.000Z');
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: '123e4567-e89b-12d3-a456-426614174000',
+          station: 'WASHING',
+          staffId: 'staff-worker',
+          status: 'IN_PROGRESS',
+          order: {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            status: 'LAUNDRY_BEING_WASHED',
+            paymentStatus: 'UNPAID',
+            outletId: 'outlet-1',
+          },
+          stationItems: [],
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: '123e4567-e89b-12d3-a456-426614174000',
+          station: 'WASHING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn().mockResolvedValue({
+          id: 'station-record-2',
+        }),
+      },
+      orderItem: {
+        findMany: jest.fn().mockResolvedValue([
+          { laundryItemId: VALID_UUID, quantity: 5 },
+        ]),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: { create: jest.fn() },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+    (prisma.staff.findFirst as jest.Mock).mockResolvedValue({
+      id: 'staff-ironing',
+    });
+
+    const response = await request(app)
+      .post('/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000/process')
+      .send({
+        items: [{ laundryItemId: VALID_UUID, quantity: 5 }],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker order processed successfully',
+      data: {
+        orderId: '123e4567-e89b-12d3-a456-426614174000',
+        stationRecordId: 'station-record-1',
+        station: 'WASHING',
+        stationStatus: 'COMPLETED',
+        orderStatus: 'LAUNDRY_BEING_IRONED',
+        completedAt: '2026-04-18T02:00:00.000Z',
       },
     });
   });

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -362,4 +362,152 @@ describe('Worker Order Routes', () => {
       },
     });
   });
+
+  it('completes packing for unpaid orders and moves them to waiting for payment', async () => {
+    mockWorkerAuth({ workerType: 'PACKING' });
+    const completedAt = new Date('2026-04-18T03:00:00.000Z');
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'station-record-3',
+            orderId: '123e4567-e89b-12d3-a456-426614174000',
+            station: 'PACKING',
+            staffId: 'staff-worker',
+            status: 'IN_PROGRESS',
+            order: {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              status: 'LAUNDRY_BEING_PACKED',
+              paymentStatus: 'UNPAID',
+              outletId: 'outlet-1',
+            },
+            stationItems: [],
+          })
+          .mockResolvedValueOnce({
+            id: 'station-record-2',
+            station: 'IRONING',
+            stationItems: [{ laundryItemId: VALID_UUID, quantity: 2 }],
+          }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-3',
+          orderId: '123e4567-e89b-12d3-a456-426614174000',
+          station: 'PACKING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn(),
+      },
+      orderItem: {
+        findMany: jest.fn(),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: {
+        create: jest.fn(),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+
+    const response = await request(app)
+      .post('/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000/process')
+      .send({
+        items: [{ laundryItemId: VALID_UUID, quantity: 2 }],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker order processed successfully',
+      data: {
+        orderId: '123e4567-e89b-12d3-a456-426614174000',
+        stationRecordId: 'station-record-3',
+        station: 'PACKING',
+        stationStatus: 'COMPLETED',
+        orderStatus: 'WAITING_FOR_PAYMENT',
+        completedAt: '2026-04-18T03:00:00.000Z',
+      },
+    });
+  });
+
+  it('completes packing for paid orders and marks them ready for delivery', async () => {
+    mockWorkerAuth({ workerType: 'PACKING' });
+    const completedAt = new Date('2026-04-18T04:00:00.000Z');
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'station-record-4',
+            orderId: '123e4567-e89b-12d3-a456-426614174000',
+            station: 'PACKING',
+            staffId: 'staff-worker',
+            status: 'IN_PROGRESS',
+            order: {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              status: 'LAUNDRY_BEING_PACKED',
+              paymentStatus: 'PAID',
+              outletId: 'outlet-1',
+            },
+            stationItems: [],
+          })
+          .mockResolvedValueOnce({
+            id: 'station-record-2',
+            station: 'IRONING',
+            stationItems: [{ laundryItemId: VALID_UUID, quantity: 4 }],
+          }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-4',
+          orderId: '123e4567-e89b-12d3-a456-426614174000',
+          station: 'PACKING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn(),
+      },
+      orderItem: {
+        findMany: jest.fn(),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: {
+        create: jest.fn().mockResolvedValue({ id: 'delivery-1' }),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+
+    const response = await request(app)
+      .post('/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000/process')
+      .send({
+        items: [{ laundryItemId: VALID_UUID, quantity: 4 }],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker order processed successfully',
+      data: {
+        orderId: '123e4567-e89b-12d3-a456-426614174000',
+        stationRecordId: 'station-record-4',
+        station: 'PACKING',
+        stationStatus: 'COMPLETED',
+        orderStatus: 'LAUNDRY_READY_FOR_DELIVERY',
+        completedAt: '2026-04-18T04:00:00.000Z',
+      },
+    });
+  });
 });

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -9,7 +9,8 @@ jest.mock('@/application/database', () => ({
   prisma: {
     user: { findUnique: jest.fn() },
     staff: { findUnique: jest.fn() },
-    stationRecord: { findMany: jest.fn(), count: jest.fn() },
+    stationRecord: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    orderItem: { findMany: jest.fn() },
   },
 }));
 
@@ -131,6 +132,97 @@ describe('Worker Order Routes', () => {
         limit: 10,
         total: 1,
         totalPages: 1,
+      },
+    });
+  });
+
+  it('returns 400 for invalid worker order id param', async () => {
+    mockWorkerAuth();
+
+    const response = await request(app).get('/api/v1/worker/orders/not-a-uuid');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 when worker order detail is not found', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get(
+      '/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.errors).toBe('Worker order not found');
+  });
+
+  it('returns worker order detail with comparison items', async () => {
+    mockWorkerAuth();
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue({
+      id: 'station-record-1',
+      orderId: '123e4567-e89b-12d3-a456-426614174000',
+      station: 'WASHING',
+      status: 'IN_PROGRESS',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          quantity: 4,
+          laundryItem: { name: 'Shirt' },
+        },
+      ],
+      order: {
+        status: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+        outlet: { name: 'PrimeCare BSD' },
+        pickupRequest: { customerUser: { name: 'John Doe' } },
+        items: [{ quantity: 2 }, { quantity: 3 }],
+      },
+    });
+    (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+      {
+        laundryItemId: 'item-1',
+        quantity: 5,
+        laundryItem: { name: 'Shirt' },
+      },
+    ]);
+
+    const response = await request(app).get(
+      '/api/v1/worker/orders/123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'success',
+      message: 'Worker order retrieved',
+      data: {
+        orderId: '123e4567-e89b-12d3-a456-426614174000',
+        stationRecordId: 'station-record-1',
+        station: 'WASHING',
+        previousStation: null,
+        stationStatus: 'IN_PROGRESS',
+        orderStatus: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        totalItems: 5,
+        customerName: 'John Doe',
+        outletName: 'PrimeCare BSD',
+        createdAt: '2026-04-17T08:00:00.000Z',
+        updatedAt: '2026-04-17T10:00:00.000Z',
+        referenceItems: [
+          {
+            laundryItemId: 'item-1',
+            itemName: 'Shirt',
+            quantity: 5,
+          },
+        ],
+        stationItems: [
+          {
+            laundryItemId: 'item-1',
+            itemName: 'Shirt',
+            quantity: 4,
+          },
+        ],
       },
     });
   });

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -158,12 +158,13 @@ describe('BypassRequestService', () => {
     });
 
     it('creates BypassRequest + StationItems on valid mismatch', async () => {
+      const notes = 'The item count changed after manual recount.';
       const createdBypass = {
         id: 'bp-1',
         stationRecordId,
         workerId,
         adminId: null,
-        problemDescription: null,
+        problemDescription: notes,
         status: 'PENDING',
         createdAt: new Date(),
       };
@@ -192,6 +193,7 @@ describe('BypassRequestService', () => {
 
       const result = await BypassRequestService.create(workerId, orderId, 'WASHING', {
         items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
+        notes,
       });
 
       expect(mockTx.stationItem.deleteMany).toHaveBeenCalledWith({
@@ -208,7 +210,7 @@ describe('BypassRequestService', () => {
           workerId,
           adminId: null,
           status: 'PENDING',
-          problemDescription: null,
+          problemDescription: notes,
         },
       });
 

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -135,6 +135,74 @@ describe('WorkerOrderService', () => {
     );
   });
 
+  it('returns paginated worker history', async () => {
+    (prisma.stationRecord.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'station-record-history-1',
+        orderId: 'order-history-1',
+        station: 'WASHING',
+        status: 'COMPLETED',
+        createdAt: new Date('2026-04-17T08:00:00.000Z'),
+        completedAt: new Date('2026-04-17T11:00:00.000Z'),
+        order: {
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          outlet: { name: 'PrimeCare BSD' },
+          pickupRequest: { customerUser: { name: 'John Doe' } },
+          items: [{ quantity: 2 }, { quantity: 3 }],
+        },
+      },
+    ]);
+    (prisma.stationRecord.count as jest.Mock).mockResolvedValue(1);
+
+    const result = await WorkerOrderService.getWorkerHistory(workerStaff, {
+      page: 1,
+      limit: 10,
+      station: 'WASHING',
+      date: '2026-04-17',
+    });
+
+    expect(prisma.stationRecord.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          staffId: 'staff-worker',
+          status: 'COMPLETED',
+          station: 'WASHING',
+          order: { outletId: 'outlet-1' },
+          completedAt: {
+            gte: new Date('2026-04-17T00:00:00.000Z'),
+            lte: new Date('2026-04-17T23:59:59.999Z'),
+          },
+        }),
+        skip: 0,
+        take: 10,
+        orderBy: { completedAt: 'desc' },
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: 'station-record-history-1',
+          orderId: 'order-history-1',
+          station: 'WASHING',
+          status: 'COMPLETED',
+          totalItems: 5,
+          updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+          createdAt: new Date('2026-04-17T08:00:00.000Z'),
+          customerName: 'John Doe',
+          outletName: 'PrimeCare BSD',
+          completedAt: new Date('2026-04-17T11:00:00.000Z'),
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
   it('returns worker order detail with reference items for washing station', async () => {
     (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue({
       id: 'station-record-1',

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -399,17 +399,171 @@ describe('WorkerOrderService', () => {
     });
   });
 
-  it('throws 422 when trying to process packing via PCS-137 flow', async () => {
-    await expect(
-      WorkerOrderService.processWorkerOrder(
-        { ...workerStaff, workerType: 'PACKING' },
-        'order-1',
-        {
-          items: [{ laundryItemId: 'item-1', quantity: 1 }],
-        },
-      ),
-    ).rejects.toThrow(
-      new ResponseError(422, 'Packing completion is handled separately'),
+  it('completes packing and moves unpaid orders to waiting for payment', async () => {
+    const completedAt = new Date('2026-04-18T03:00:00.000Z');
+    const packingWorker = { ...workerStaff, workerType: 'PACKING' };
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'station-record-3',
+            orderId: 'order-2',
+            station: 'PACKING',
+            staffId: 'staff-worker',
+            status: 'IN_PROGRESS',
+            order: {
+              id: 'order-2',
+              status: 'LAUNDRY_BEING_PACKED',
+              paymentStatus: 'UNPAID',
+              outletId: 'outlet-1',
+            },
+            stationItems: [],
+          })
+          .mockResolvedValueOnce({
+            id: 'station-record-2',
+            station: 'IRONING',
+            stationItems: [{ laundryItemId: 'item-1', quantity: 2 }],
+          }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-3',
+          orderId: 'order-2',
+          station: 'PACKING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn(),
+      },
+      orderItem: {
+        findMany: jest.fn(),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: {
+        create: jest.fn(),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
     );
+
+    const result = await WorkerOrderService.processWorkerOrder(
+      packingWorker,
+      'order-2',
+      {
+        items: [{ laundryItemId: 'item-1', quantity: 2 }],
+      },
+    );
+
+    expect(mockTx.order.update).toHaveBeenCalledWith({
+      where: { id: 'order-2' },
+      data: { status: 'WAITING_FOR_PAYMENT' },
+    });
+    expect(mockTx.delivery.create).not.toHaveBeenCalled();
+    expect(prisma.staff.findFirst).not.toHaveBeenCalled();
+    expect(mockTx.stationRecord.create).not.toHaveBeenCalled();
+    expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+      orderId: 'order-2',
+      outletId: 'outlet-1',
+      orderStatus: 'WAITING_FOR_PAYMENT',
+    });
+    expect(result).toEqual({
+      orderId: 'order-2',
+      stationRecordId: 'station-record-3',
+      station: 'PACKING',
+      stationStatus: 'COMPLETED',
+      orderStatus: 'WAITING_FOR_PAYMENT',
+      completedAt,
+    });
+  });
+
+  it('completes packing and creates delivery when the order is already paid', async () => {
+    const completedAt = new Date('2026-04-18T04:00:00.000Z');
+    const packingWorker = { ...workerStaff, workerType: 'PACKING' };
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'station-record-4',
+            orderId: 'order-3',
+            station: 'PACKING',
+            staffId: 'staff-worker',
+            status: 'IN_PROGRESS',
+            order: {
+              id: 'order-3',
+              status: 'LAUNDRY_BEING_PACKED',
+              paymentStatus: 'PAID',
+              outletId: 'outlet-1',
+            },
+            stationItems: [],
+          })
+          .mockResolvedValueOnce({
+            id: 'station-record-2',
+            station: 'IRONING',
+            stationItems: [{ laundryItemId: 'item-1', quantity: 4 }],
+          }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-4',
+          orderId: 'order-3',
+          station: 'PACKING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn(),
+      },
+      orderItem: {
+        findMany: jest.fn(),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: {
+        create: jest.fn().mockResolvedValue({ id: 'delivery-1' }),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+
+    const result = await WorkerOrderService.processWorkerOrder(
+      packingWorker,
+      'order-3',
+      {
+        items: [{ laundryItemId: 'item-1', quantity: 4 }],
+      },
+    );
+
+    expect(mockTx.delivery.create).toHaveBeenCalledWith({
+      data: { orderId: 'order-3' },
+    });
+    expect(mockTx.order.update).toHaveBeenCalledWith({
+      where: { id: 'order-3' },
+      data: { status: 'LAUNDRY_READY_FOR_DELIVERY' },
+    });
+    expect(prisma.staff.findFirst).not.toHaveBeenCalled();
+    expect(mockTx.stationRecord.create).not.toHaveBeenCalled();
+    expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+      orderId: 'order-3',
+      outletId: 'outlet-1',
+      orderStatus: 'LAUNDRY_READY_FOR_DELIVERY',
+    });
+    expect(result).toEqual({
+      orderId: 'order-3',
+      stationRecordId: 'station-record-4',
+      station: 'PACKING',
+      stationStatus: 'COMPLETED',
+      orderStatus: 'LAUNDRY_READY_FOR_DELIVERY',
+      completedAt,
+    });
   });
 });

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -3,6 +3,10 @@ jest.mock('@/application/database', () => ({
     stationRecord: {
       findMany: jest.fn(),
       count: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    orderItem: {
+      findMany: jest.fn(),
     },
   },
 }));
@@ -118,5 +122,108 @@ describe('WorkerOrderService', () => {
         take: 5,
       }),
     );
+  });
+
+  it('returns worker order detail with reference items for washing station', async () => {
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue({
+      id: 'station-record-1',
+      orderId: 'order-1',
+      station: 'WASHING',
+      status: 'IN_PROGRESS',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          quantity: 4,
+          laundryItem: { name: 'Shirt' },
+        },
+      ],
+      order: {
+        status: 'LAUNDRY_BEING_WASHED',
+        paymentStatus: 'UNPAID',
+        updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+        outlet: { name: 'PrimeCare BSD' },
+        pickupRequest: { customerUser: { name: 'John Doe' } },
+        items: [{ quantity: 2 }, { quantity: 3 }],
+      },
+    });
+    (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+      {
+        laundryItemId: 'item-1',
+        quantity: 5,
+        laundryItem: { name: 'Shirt' },
+      },
+    ]);
+
+    const result = await WorkerOrderService.getWorkerOrderDetail(
+      workerStaff,
+      'order-1',
+    );
+
+    expect(prisma.stationRecord.findFirst).toHaveBeenCalledWith({
+      where: {
+        orderId: 'order-1',
+        station: 'WASHING',
+        order: { outletId: 'outlet-1' },
+      },
+      include: {
+        stationItems: {
+          include: {
+            laundryItem: {
+              select: { name: true },
+            },
+          },
+        },
+        order: {
+          include: {
+            outlet: true,
+            pickupRequest: {
+              include: {
+                customerUser: {
+                  select: { name: true },
+                },
+              },
+            },
+            items: true,
+          },
+        },
+      },
+    });
+    expect(result).toEqual({
+      orderId: 'order-1',
+      stationRecordId: 'station-record-1',
+      station: 'WASHING',
+      previousStation: null,
+      stationStatus: 'IN_PROGRESS',
+      orderStatus: 'LAUNDRY_BEING_WASHED',
+      paymentStatus: 'UNPAID',
+      totalItems: 5,
+      customerName: 'John Doe',
+      outletName: 'PrimeCare BSD',
+      createdAt: new Date('2026-04-17T08:00:00.000Z'),
+      updatedAt: new Date('2026-04-17T10:00:00.000Z'),
+      referenceItems: [
+        {
+          laundryItemId: 'item-1',
+          itemName: 'Shirt',
+          quantity: 5,
+        },
+      ],
+      stationItems: [
+        {
+          laundryItemId: 'item-1',
+          itemName: 'Shirt',
+          quantity: 4,
+        },
+      ],
+    });
+  });
+
+  it('throws 404 when worker order detail is not found', async () => {
+    (prisma.stationRecord.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      WorkerOrderService.getWorkerOrderDetail(workerStaff, 'order-404'),
+    ).rejects.toThrow(new ResponseError(404, 'Worker order not found'));
   });
 });

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -1,8 +1,12 @@
 jest.mock('@/application/database', () => ({
   prisma: {
+    $transaction: jest.fn(),
     stationRecord: {
       findMany: jest.fn(),
       count: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    staff: {
       findFirst: jest.fn(),
     },
     orderItem: {
@@ -11,8 +15,15 @@ jest.mock('@/application/database', () => ({
   },
 }));
 
+jest.mock('@/features/worker-notifications/worker-notification-service', () => ({
+  WorkerNotificationService: {
+    publishOrderArrival: jest.fn(),
+  },
+}));
+
 import { prisma } from '@/application/database';
 import { ResponseError } from '@/error/response-error';
+import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 import { WorkerOrderService } from '@/features/worker-orders/worker-order-service';
 
 describe('WorkerOrderService', () => {
@@ -225,5 +236,180 @@ describe('WorkerOrderService', () => {
     await expect(
       WorkerOrderService.getWorkerOrderDetail(workerStaff, 'order-404'),
     ).rejects.toThrow(new ResponseError(404, 'Worker order not found'));
+  });
+
+  it('throws 400 when submitted quantities do not match the reference items', async () => {
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          staffId: 'staff-worker',
+          status: 'IN_PROGRESS',
+          order: {
+            id: 'order-1',
+            status: 'LAUNDRY_BEING_WASHED',
+            paymentStatus: 'UNPAID',
+            outletId: 'outlet-1',
+          },
+          stationItems: [],
+        }),
+      },
+      orderItem: {
+        findMany: jest.fn().mockResolvedValue([
+          { laundryItemId: 'item-1', quantity: 5 },
+        ]),
+      },
+      stationItem: {
+        deleteMany: jest.fn(),
+        createMany: jest.fn(),
+      },
+      order: {
+        update: jest.fn(),
+      },
+      delivery: {
+        create: jest.fn(),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+
+    await expect(
+      WorkerOrderService.processWorkerOrder(workerStaff, 'order-1', {
+        items: [{ laundryItemId: 'item-1', quantity: 3 }],
+      }),
+    ).rejects.toThrow(new ResponseError(400, 'Quantity mismatch detected'));
+    expect(mockTx.stationItem.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('processes a washing order and advances it to ironing', async () => {
+    const completedAt = new Date('2026-04-18T02:00:00.000Z');
+    const mockTx = {
+      stationRecord: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          staffId: 'staff-worker',
+          status: 'IN_PROGRESS',
+          order: {
+            id: 'order-1',
+            status: 'LAUNDRY_BEING_WASHED',
+            paymentStatus: 'UNPAID',
+            outletId: 'outlet-1',
+          },
+          stationItems: [],
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'station-record-1',
+          orderId: 'order-1',
+          station: 'WASHING',
+          status: 'COMPLETED',
+          completedAt,
+        }),
+        create: jest.fn().mockResolvedValue({
+          id: 'station-record-2',
+        }),
+      },
+      orderItem: {
+        findMany: jest.fn().mockResolvedValue([
+          { laundryItemId: 'item-1', quantity: 5 },
+        ]),
+      },
+      stationItem: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        update: jest.fn().mockResolvedValue({}),
+      },
+      delivery: {
+        create: jest.fn(),
+      },
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(mockTx),
+    );
+    (prisma.staff.findFirst as jest.Mock).mockResolvedValue({
+      id: 'staff-ironing',
+    });
+
+    const result = await WorkerOrderService.processWorkerOrder(
+      workerStaff,
+      'order-1',
+      {
+        items: [{ laundryItemId: 'item-1', quantity: 5 }],
+      },
+    );
+
+    expect(mockTx.stationItem.deleteMany).toHaveBeenCalledWith({
+      where: { stationRecordId: 'station-record-1' },
+    });
+    expect(mockTx.stationItem.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          stationRecordId: 'station-record-1',
+          laundryItemId: 'item-1',
+          quantity: 5,
+        },
+      ],
+    });
+    expect(mockTx.stationRecord.update).toHaveBeenCalledWith({
+      where: { id: 'station-record-1' },
+      data: {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
+      },
+    });
+    expect(mockTx.order.update).toHaveBeenCalledWith({
+      where: { id: 'order-1' },
+      data: { status: 'LAUNDRY_BEING_IRONED' },
+    });
+    expect(prisma.staff.findFirst).toHaveBeenCalledWith({
+      where: {
+        role: 'WORKER',
+        isActive: true,
+        outletId: 'outlet-1',
+        workerType: 'IRONING',
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+    expect(mockTx.stationRecord.create).toHaveBeenCalledWith({
+      data: {
+        orderId: 'order-1',
+        station: 'IRONING',
+        staffId: 'staff-ironing',
+        status: 'IN_PROGRESS',
+      },
+    });
+    expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+      orderId: 'order-1',
+      outletId: 'outlet-1',
+      orderStatus: 'LAUNDRY_BEING_IRONED',
+    });
+    expect(result).toEqual({
+      orderId: 'order-1',
+      stationRecordId: 'station-record-1',
+      station: 'WASHING',
+      stationStatus: 'COMPLETED',
+      orderStatus: 'LAUNDRY_BEING_IRONED',
+      completedAt,
+    });
+  });
+
+  it('throws 422 when trying to process packing via PCS-137 flow', async () => {
+    await expect(
+      WorkerOrderService.processWorkerOrder(
+        { ...workerStaff, workerType: 'PACKING' },
+        'order-1',
+        {
+          items: [{ laundryItemId: 'item-1', quantity: 1 }],
+        },
+      ),
+    ).rejects.toThrow(
+      new ResponseError(422, 'Packing completion is handled separately'),
+    );
   });
 });


### PR DESCRIPTION
### What changed
- added `GET /api/v1/worker/history`
- added paginated worker history retrieval for completed station records assigned to the authenticated worker
- added optional filtering by:
  - `station`
  - `date`
- added standard response envelope with `data` and `meta`
- refactored worker-order backend files to keep service/model size aligned with project rules by extracting:
  - worker order helpers
  - worker order mappers
  - worker order read/query logic

### Why
- implements PCS-144 `GET /worker/history`
- allows workers to review their completed processing history with pagination and filters

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/worker-order-service.test.ts --runInBand`
   - `npx jest tests/integration/worker-order-routes.test.ts --runInBand`
3. authenticate as a `WORKER`
4. call `GET /api/v1/worker/history`
5. verify the response includes:
   - `status`
   - `message`
   - `data`
   - `meta`
6. test optional query params:
   - `page`
   - `limit`
   - `station`
   - `date`
7. verify only completed station records assigned to the current worker are returned

### Notes
- this endpoint reads completed `stationRecord` data for the authenticated worker
- filtering by `date` uses the station record `completedAt` timestamp
- no unrelated untracked local files were included in this PR
