### PR TITLE
feat: add admin outlet crud endpoints

### DIFF
--- a/src/features/admin-outlets/admin-outlet-controller.ts
+++ b/src/features/admin-outlets/admin-outlet-controller.ts
@@ -1,0 +1,58 @@
+import { NextFunction, Response } from 'express'
+import { UserRequest } from '@/types/user-request'
+import { Validation } from '@/validations/validation'
+import { AdminOutletValidation } from '@/validations/admin-outlet-validation'
+import { AdminOutletService } from './admin-outlet-service'
+
+const getId = (req: UserRequest) =>
+  Validation.validate(AdminOutletValidation.PARAMS, { id: req.params.id }).id
+
+export class AdminOutletController {
+  static async getAdminOutlets(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(AdminOutletValidation.QUERY, req.query)
+      const result = await AdminOutletService.getAdminOutlets(req.staff!, query)
+      res.status(200).json({ status: 'success', message: 'Outlets retrieved successfully', data: result.data, meta: result.meta })
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  static async createAdminOutlet(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const data = Validation.validate(AdminOutletValidation.CREATE, req.body)
+      const result = await AdminOutletService.createAdminOutlet(data)
+      res.status(201).json({ status: 'success', message: 'Outlet created successfully', data: result })
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  static async getAdminOutletDetail(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const result = await AdminOutletService.getAdminOutletDetail(req.staff!, getId(req))
+      res.status(200).json({ status: 'success', message: 'Outlet retrieved successfully', data: result })
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  static async updateAdminOutlet(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const data = Validation.validate(AdminOutletValidation.UPDATE, req.body)
+      const result = await AdminOutletService.updateAdminOutlet(getId(req), data)
+      res.status(200).json({ status: 'success', message: 'Outlet updated successfully', data: result })
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  static async deactivateAdminOutlet(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const result = await AdminOutletService.deactivateAdminOutlet(getId(req))
+      res.status(200).json({ status: 'success', message: result.message })
+    } catch (error) {
+      next(error)
+    }
+  }
+}

--- a/src/features/admin-outlets/admin-outlet-model.ts
+++ b/src/features/admin-outlets/admin-outlet-model.ts
@@ -1,0 +1,52 @@
+export type CreateAdminOutletInput = {
+  name: string
+  address: string
+  city: string
+  province: string
+  latitude: number
+  longitude: number
+  maxServiceRadiusKm?: number
+}
+
+export type UpdateAdminOutletInput = Partial<CreateAdminOutletInput> & {
+  isActive?: boolean
+}
+
+export type GetAdminOutletsQuery = {
+  page: number
+  limit: number
+  search?: string
+  isActive?: boolean
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+}
+
+export type AdminOutletResponse = {
+  id: string
+  name: string
+  address: string
+  city: string
+  province: string
+  latitude: number
+  longitude: number
+  maxServiceRadiusKm: number
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+type OutletLike = AdminOutletResponse
+
+export const toAdminOutletResponse = (outlet: OutletLike): AdminOutletResponse => ({
+  id: outlet.id,
+  name: outlet.name,
+  address: outlet.address,
+  city: outlet.city,
+  province: outlet.province,
+  latitude: outlet.latitude,
+  longitude: outlet.longitude,
+  maxServiceRadiusKm: outlet.maxServiceRadiusKm,
+  isActive: outlet.isActive,
+  createdAt: outlet.createdAt,
+  updatedAt: outlet.updatedAt,
+})

--- a/src/features/admin-outlets/admin-outlet-service.ts
+++ b/src/features/admin-outlets/admin-outlet-service.ts
@@ -1,0 +1,118 @@
+import { prisma } from '@/application/database'
+import { ResponseError } from '@/error/response-error'
+import { StaffRole } from '@/generated/prisma/enums'
+import {
+  CreateAdminOutletInput,
+  GetAdminOutletsQuery,
+  UpdateAdminOutletInput,
+  toAdminOutletResponse,
+} from './admin-outlet-model'
+
+const VALID_OUTLET_SORT = ['createdAt', 'name', 'city', 'province'] as const
+type OutletSortField = (typeof VALID_OUTLET_SORT)[number]
+
+const assertOutletAdminScope = (staff: { role: StaffRole; outletId?: string | null }) => {
+  if (staff.role === StaffRole.OUTLET_ADMIN && !staff.outletId) {
+    throw new ResponseError(422, 'Outlet admin outlet assignment is not configured')
+  }
+}
+
+const buildOutletWhere = (
+  staff: { role: StaffRole; outletId?: string | null },
+  query: GetAdminOutletsQuery,
+) => {
+  const where: Record<string, unknown> = {}
+
+  if (staff.role === StaffRole.OUTLET_ADMIN) where.id = staff.outletId
+  if (query.isActive !== undefined) where.isActive = query.isActive
+  if (!query.search) return where
+
+  where.OR = [
+    { name: { contains: query.search, mode: 'insensitive' } },
+    { address: { contains: query.search, mode: 'insensitive' } },
+    { city: { contains: query.search, mode: 'insensitive' } },
+    { province: { contains: query.search, mode: 'insensitive' } },
+  ]
+
+  return where
+}
+
+const getValidOrderBy = (sortBy?: string, sortOrder?: 'asc' | 'desc') => {
+  const field: OutletSortField = VALID_OUTLET_SORT.includes(sortBy as OutletSortField)
+    ? (sortBy as OutletSortField)
+    : 'createdAt'
+  return { [field]: sortOrder === 'asc' ? 'asc' : 'desc' }
+}
+
+const findOutletOrThrow = async (id: string) => {
+  const outlet = await prisma.outlet.findUnique({ where: { id } })
+  if (!outlet) throw new ResponseError(404, 'Outlet not found')
+  return outlet
+}
+
+const assertOutletAccess = (
+  staff: { role: StaffRole; outletId?: string | null },
+  outletId: string,
+) => {
+  if (staff.role === StaffRole.OUTLET_ADMIN && staff.outletId !== outletId) {
+    throw new ResponseError(403, 'Forbidden')
+  }
+}
+
+export class AdminOutletService {
+  static async getAdminOutlets(
+    staff: { role: StaffRole; outletId?: string | null },
+    query: GetAdminOutletsQuery,
+  ) {
+    assertOutletAdminScope(staff)
+
+    const where = buildOutletWhere(staff, query)
+    const skip = (query.page - 1) * query.limit
+    const orderBy = getValidOrderBy(query.sortBy, query.sortOrder)
+
+    const [outlets, total] = await prisma.$transaction([
+      prisma.outlet.findMany({ where, skip, take: query.limit, orderBy }),
+      prisma.outlet.count({ where }),
+    ])
+
+    return {
+      data: outlets.map(toAdminOutletResponse),
+      meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) },
+    }
+  }
+
+  static async createAdminOutlet(data: CreateAdminOutletInput) {
+    const existing = await prisma.outlet.findFirst({
+      where: { name: data.name, address: data.address, city: data.city, province: data.province },
+    })
+    if (existing) throw new ResponseError(409, 'Outlet already exists')
+
+    const outlet = await prisma.outlet.create({
+      data: { ...data, maxServiceRadiusKm: data.maxServiceRadiusKm ?? 10 },
+    })
+
+    return toAdminOutletResponse(outlet)
+  }
+
+  static async getAdminOutletDetail(
+    staff: { role: StaffRole; outletId?: string | null },
+    id: string,
+  ) {
+    assertOutletAdminScope(staff)
+    const outlet = await findOutletOrThrow(id)
+    assertOutletAccess(staff, outlet.id)
+    return toAdminOutletResponse(outlet)
+  }
+
+  static async updateAdminOutlet(id: string, data: UpdateAdminOutletInput) {
+    await findOutletOrThrow(id)
+    const outlet = await prisma.outlet.update({ where: { id }, data })
+    return toAdminOutletResponse(outlet)
+  }
+
+  static async deactivateAdminOutlet(id: string) {
+    await findOutletOrThrow(id)
+    await prisma.outlet.update({ where: { id }, data: { isActive: false } })
+    return { message: 'Outlet deactivated successfully' }
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -8,6 +8,7 @@ import {
 import { UserController } from '@/features/users/user-controller';
 import { AdminUserController } from '@/features/admin-users/admin-user-controller';
 import { AdminOrderController } from '@/features/admin-orders/admin-order-controller';
+import { AdminOutletController } from '@/features/admin-outlets/admin-outlet-controller';
 import { AddressController } from '@/features/addresses/address-controller';
 import { RegionController } from '@/features/region-data/region-controller';
 import { BypassRequestController } from '@/features/bypass-requests/bypass-request-controller';
@@ -91,6 +92,31 @@ apiRouter.post(
   '/admin/users',
   requireStaffRole('SUPER_ADMIN'),
   AdminUserController.createAdminUser,
+);
+apiRouter.get(
+  '/admin/outlets',
+  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
+  AdminOutletController.getAdminOutlets,
+);
+apiRouter.get(
+  '/admin/outlets/:id',
+  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
+  AdminOutletController.getAdminOutletDetail,
+);
+apiRouter.post(
+  '/admin/outlets',
+  requireStaffRole('SUPER_ADMIN'),
+  AdminOutletController.createAdminOutlet,
+);
+apiRouter.patch(
+  '/admin/outlets/:id',
+  requireStaffRole('SUPER_ADMIN'),
+  AdminOutletController.updateAdminOutlet,
+);
+apiRouter.delete(
+  '/admin/outlets/:id',
+  requireStaffRole('SUPER_ADMIN'),
+  AdminOutletController.deactivateAdminOutlet,
 );
 apiRouter.patch(
   '/admin/users/:id',

--- a/src/validations/admin-outlet-validation.ts
+++ b/src/validations/admin-outlet-validation.ts
@@ -1,0 +1,44 @@
+import { z, ZodType } from 'zod'
+import {
+  CreateAdminOutletInput,
+  GetAdminOutletsQuery,
+  UpdateAdminOutletInput,
+} from '@/features/admin-outlets/admin-outlet-model'
+
+export class AdminOutletValidation {
+  static readonly PARAMS = z.object({ id: z.string().uuid() })
+
+  static readonly QUERY: ZodType<GetAdminOutletsQuery> = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    search: z.string().trim().min(1).optional(),
+    isActive: z
+      .union([z.boolean(), z.enum(['true', 'false']).transform((value) => value === 'true')])
+      .optional(),
+    sortBy: z.enum(['createdAt', 'name', 'city', 'province']).optional(),
+    sortOrder: z.enum(['asc', 'desc']).optional(),
+  })
+
+  static readonly CREATE: ZodType<CreateAdminOutletInput> = z.object({
+    name: z.string().trim().min(2),
+    address: z.string().trim().min(5),
+    city: z.string().trim().min(2),
+    province: z.string().trim().min(2),
+    latitude: z.coerce.number().finite(),
+    longitude: z.coerce.number().finite(),
+    maxServiceRadiusKm: z.coerce.number().positive().optional(),
+  })
+
+  static readonly UPDATE: ZodType<UpdateAdminOutletInput> = z
+    .object({
+      name: z.string().trim().min(2).optional(),
+      address: z.string().trim().min(5).optional(),
+      city: z.string().trim().min(2).optional(),
+      province: z.string().trim().min(2).optional(),
+      latitude: z.coerce.number().finite().optional(),
+      longitude: z.coerce.number().finite().optional(),
+      maxServiceRadiusKm: z.coerce.number().positive().optional(),
+      isActive: z.boolean().optional(),
+    })
+    .refine((data) => Object.keys(data).length > 0, { message: 'At least one field is required' })
+}

--- a/tests/integration/admin-outlet-routes.test.ts
+++ b/tests/integration/admin-outlet-routes.test.ts
@@ -1,0 +1,175 @@
+import type { Request, Response } from 'express'
+
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((headers: Record<string, string | string[] | undefined>) => headers),
+  toNodeHandler: jest.fn(() => (_req: Request, res: Response) => res.json({ ok: true })),
+}))
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn() },
+    outlet: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}))
+
+jest.mock('@/utils/auth', () => ({
+  auth: {
+    api: { getSession: jest.fn() },
+  },
+}))
+
+import request from 'supertest'
+import { app } from '@/application/app'
+import { prisma } from '@/application/database'
+import { auth } from '@/utils/auth'
+
+const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('Admin Outlet Routes Integration Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(prisma.$transaction as jest.Mock).mockImplementation((ops: Promise<unknown>[]) => Promise.all(ops))
+  })
+
+  it('returns outlets for SUPER_ADMIN', async () => {
+    ;(auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: { id: 'user-1' }, session: 'token' })
+    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' })
+    ;(prisma.staff.findUnique as jest.Mock).mockResolvedValue({ id: 'staff-1', role: 'SUPER_ADMIN', isActive: true })
+    ;(prisma.outlet.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: VALID_UUID,
+        name: 'Outlet One',
+        address: 'Jl. Mawar 1',
+        city: 'Bandung',
+        province: 'Jawa Barat',
+        latitude: -6.9,
+        longitude: 107.6,
+        maxServiceRadiusKm: 10,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    ;(prisma.outlet.count as jest.Mock).mockResolvedValue(1)
+
+    const response = await request(app).get('/api/v1/admin/outlets')
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body.data)).toBe(true)
+  })
+
+  it('creates outlet for SUPER_ADMIN', async () => {
+    ;(auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: { id: 'user-1' }, session: 'token' })
+    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' })
+    ;(prisma.staff.findUnique as jest.Mock).mockResolvedValue({ id: 'staff-1', role: 'SUPER_ADMIN', isActive: true })
+    ;(prisma.outlet.findFirst as jest.Mock).mockResolvedValue(null)
+    ;(prisma.outlet.create as jest.Mock).mockResolvedValue({
+      id: VALID_UUID,
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+      maxServiceRadiusKm: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const response = await request(app).post('/api/v1/admin/outlets').send({
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+    })
+
+    expect(response.status).toBe(201)
+  })
+
+  it('returns 403 when OUTLET_ADMIN tries to create outlet', async () => {
+    ;(auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: { id: 'user-1' }, session: 'token' })
+    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' })
+    ;(prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+      id: 'staff-1',
+      role: 'OUTLET_ADMIN',
+      isActive: true,
+      outletId: VALID_UUID,
+    })
+
+    const response = await request(app).post('/api/v1/admin/outlets').send({
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+    })
+
+    expect(response.status).toBe(403)
+  })
+
+  it('returns outlet detail for OUTLET_ADMIN own outlet', async () => {
+    ;(auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: { id: 'user-1' }, session: 'token' })
+    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' })
+    ;(prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+      id: 'staff-1',
+      role: 'OUTLET_ADMIN',
+      isActive: true,
+      outletId: VALID_UUID,
+    })
+    ;(prisma.outlet.findUnique as jest.Mock).mockResolvedValue({
+      id: VALID_UUID,
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+      maxServiceRadiusKm: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const response = await request(app).get(`/api/v1/admin/outlets/${VALID_UUID}`)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('soft-deactivates outlet for SUPER_ADMIN', async () => {
+    ;(auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: { id: 'user-1' }, session: 'token' })
+    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' })
+    ;(prisma.staff.findUnique as jest.Mock).mockResolvedValue({ id: 'staff-1', role: 'SUPER_ADMIN', isActive: true })
+    ;(prisma.outlet.findUnique as jest.Mock).mockResolvedValue({
+      id: VALID_UUID,
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+      maxServiceRadiusKm: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    ;(prisma.outlet.update as jest.Mock).mockResolvedValue({ id: VALID_UUID, isActive: false })
+
+    const response = await request(app).delete(`/api/v1/admin/outlets/${VALID_UUID}`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.message).toBe('Outlet deactivated successfully')
+  })
+})

--- a/tests/unit/admin-outlet-service.test.ts
+++ b/tests/unit/admin-outlet-service.test.ts
@@ -1,0 +1,140 @@
+jest.mock('@/application/database', () => ({
+  prisma: {
+    outlet: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}))
+
+import { prisma } from '@/application/database'
+import { AdminOutletService } from '@/features/admin-outlets/admin-outlet-service'
+
+const superAdmin = { role: 'SUPER_ADMIN' as const, outletId: null }
+const outletAdmin = { role: 'OUTLET_ADMIN' as const, outletId: 'outlet-1' }
+
+describe('AdminOutletService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(prisma.$transaction as jest.Mock).mockImplementation((ops: Promise<unknown>[]) => Promise.all(ops))
+  })
+
+  it('returns paginated outlets for SUPER_ADMIN', async () => {
+    ;(prisma.outlet.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'outlet-1',
+        name: 'Outlet One',
+        address: 'Jl. Mawar 1',
+        city: 'Bandung',
+        province: 'Jawa Barat',
+        latitude: -6.9,
+        longitude: 107.6,
+        maxServiceRadiusKm: 10,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    ;(prisma.outlet.count as jest.Mock).mockResolvedValue(1)
+
+    const result = await AdminOutletService.getAdminOutlets(superAdmin, { page: 1, limit: 10 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.meta.total).toBe(1)
+  })
+
+  it('scopes outlet list for OUTLET_ADMIN', async () => {
+    ;(prisma.outlet.findMany as jest.Mock).mockResolvedValue([])
+    ;(prisma.outlet.count as jest.Mock).mockResolvedValue(0)
+
+    await AdminOutletService.getAdminOutlets(outletAdmin, { page: 1, limit: 10 })
+
+    expect(prisma.outlet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: 'outlet-1' }) }),
+    )
+  })
+
+  it('creates new outlet', async () => {
+    ;(prisma.outlet.findFirst as jest.Mock).mockResolvedValue(null)
+    ;(prisma.outlet.create as jest.Mock).mockResolvedValue({
+      id: 'outlet-2',
+      name: 'Outlet Two',
+      address: 'Jl. Melati 2',
+      city: 'Jakarta',
+      province: 'DKI Jakarta',
+      latitude: -6.2,
+      longitude: 106.8,
+      maxServiceRadiusKm: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await AdminOutletService.createAdminOutlet({
+      name: 'Outlet Two',
+      address: 'Jl. Melati 2',
+      city: 'Jakarta',
+      province: 'DKI Jakarta',
+      latitude: -6.2,
+      longitude: 106.8,
+    })
+
+    expect(result.id).toBe('outlet-2')
+  })
+
+  it('throws 409 for duplicate outlet', async () => {
+    ;(prisma.outlet.findFirst as jest.Mock).mockResolvedValue({ id: 'outlet-1' })
+
+    await expect(
+      AdminOutletService.createAdminOutlet({
+        name: 'Outlet One',
+        address: 'Jl. Mawar 1',
+        city: 'Bandung',
+        province: 'Jawa Barat',
+        latitude: -6.9,
+        longitude: 107.6,
+      }),
+    ).rejects.toMatchObject({ status: 409 })
+  })
+
+  it('returns outlet detail for scoped outlet admin', async () => {
+    ;(prisma.outlet.findUnique as jest.Mock).mockResolvedValue({
+      id: 'outlet-1',
+      name: 'Outlet One',
+      address: 'Jl. Mawar 1',
+      city: 'Bandung',
+      province: 'Jawa Barat',
+      latitude: -6.9,
+      longitude: 107.6,
+      maxServiceRadiusKm: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await AdminOutletService.getAdminOutletDetail(outletAdmin, 'outlet-1')
+
+    expect(result.id).toBe('outlet-1')
+  })
+
+  it('deactivates outlet by setting isActive false', async () => {
+    ;(prisma.outlet.findUnique as jest.Mock).mockResolvedValue({
+      id: 'outlet-1',
+      name: 'Outlet One',
+    })
+    ;(prisma.outlet.update as jest.Mock).mockResolvedValue({ id: 'outlet-1', isActive: false })
+
+    const result = await AdminOutletService.deactivateAdminOutlet('outlet-1')
+
+    expect(result.message).toBe('Outlet deactivated successfully')
+    expect(prisma.outlet.update).toHaveBeenCalledWith({
+      where: { id: 'outlet-1' },
+      data: { isActive: false },
+    })
+  })
+})


### PR DESCRIPTION
### What changed
- added admin outlet CRUD backend endpoints for PCS-152:
  - `GET /api/v1/admin/outlets`
  - `POST /api/v1/admin/outlets`
  - `GET /api/v1/admin/outlets/:id`
  - `PATCH /api/v1/admin/outlets/:id`
  - `DELETE /api/v1/admin/outlets/:id`
- added outlet list pagination and filtering support:
  - `page`
  - `limit`
  - `search`
  - `isActive`
  - `sortBy`
  - `sortOrder`
- scoped outlet access by role:
  - `SUPER_ADMIN` can manage all outlets
  - `OUTLET_ADMIN` can only read their own outlet
- added outlet validation, service, controller, and test coverage

### Why
- implements backend part of PCS-152 Outlet CRUD — Super Admin
- covers PCS-165 until PCS-169
- provides the backend foundation for super admin outlet management in the frontend tasks

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/admin-outlet-service.test.ts --runInBand`
   - `npx jest tests/integration/admin-outlet-routes.test.ts --runInBand`
3. authenticate as `SUPER_ADMIN`
4. verify:
   - `GET /api/v1/admin/outlets` returns paginated outlets
   - `POST /api/v1/admin/outlets` creates a new outlet
   - `GET /api/v1/admin/outlets/:id` returns outlet detail
   - `PATCH /api/v1/admin/outlets/:id` updates outlet fields
   - `DELETE /api/v1/admin/outlets/:id` soft-deactivates the outlet
5. authenticate as `OUTLET_ADMIN`
6. verify:
   - `GET /api/v1/admin/outlets` only returns the assigned outlet
   - `GET /api/v1/admin/outlets/:id` only works for the assigned outlet
   - create/update/delete remain forbidden

### Notes
- delete is implemented as soft deactivate by setting `isActive = false`
- all newly added files were kept below the project line-count threshold
