### PR TITLE
feat: add shift management endpoints and worker shift guard

### DIFF
--- a/prisma/migrations/20260419130500_make_shift_end_time_nullable/migration.sql
+++ b/prisma/migrations/20260419130500_make_shift_end_time_nullable/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "shifts" ALTER COLUMN "end_time" DROP NOT NULL;
+
+CREATE INDEX "shifts_staff_id_end_time_idx" ON "shifts"("staff_id", "end_time");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,13 +140,14 @@ model Shift {
   id        String   @id @default(uuid())
   outletId  String   @map("outlet_id")
   startTime DateTime @map("start_time")
-  endTime   DateTime @map("end_time")
+  endTime   DateTime? @map("end_time")
   staffId   String   @map("staff_id")
   outlet    Outlet   @relation(fields: [outletId], references: [id])
   staff     Staff    @relation(fields: [staffId], references: [id])
 
   @@index([outletId])
   @@index([staffId])
+  @@index([staffId, endTime])
   @@map("shifts")
 }
 

--- a/src/features/shifts/shift-controller.ts
+++ b/src/features/shifts/shift-controller.ts
@@ -1,0 +1,53 @@
+import type { NextFunction, Response } from 'express';
+import type { UserRequest } from '@/types/user-request';
+import { Validation } from '@/validations/validation';
+import { ShiftValidation } from '@/validations/shift-validation';
+import { ShiftService } from './shift-service';
+
+export class ShiftController {
+  static async create(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const data = Validation.validate(ShiftValidation.CREATE, req.body);
+      const result = await ShiftService.createShift(req.staff!, data);
+
+      res.status(201).json({
+        status: 'success',
+        message: 'Shift created successfully',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async list(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(ShiftValidation.LIST, req.query);
+      const result = await ShiftService.getShifts(req.staff!, query);
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Shifts retrieved successfully',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async end(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const shiftId = Validation.validate(ShiftValidation.ID_PARAM, req.params.id);
+      const result = await ShiftService.endShift(req.staff!, shiftId);
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Shift ended successfully',
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/shifts/shift-helper.ts
+++ b/src/features/shifts/shift-helper.ts
@@ -1,0 +1,40 @@
+import type { Staff } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import type { ShiftResponse } from './shift-model';
+
+export const resolveManagedOutletId = (
+  staff: Staff,
+  outletId?: string,
+) => {
+  if (staff.role === 'OUTLET_ADMIN') {
+    if (!staff.outletId) {
+      throw new ResponseError(422, 'Outlet admin is not assigned to an outlet');
+    }
+    if (outletId && outletId !== staff.outletId) {
+      throw new ResponseError(403, 'Forbidden');
+    }
+
+    return staff.outletId;
+  }
+
+  return outletId;
+};
+
+export const toShiftResponse = (shift: {
+  id: string;
+  staffId: string;
+  startTime: Date;
+  endTime: Date | null;
+  staff: { workerType: string | null; user: { name: string | null } };
+  outlet: { id: string; name: string };
+}): ShiftResponse => ({
+  id: shift.id,
+  staffId: shift.staffId,
+  workerType: shift.staff.workerType,
+  workerName: shift.staff.user.name,
+  outletId: shift.outlet.id,
+  outletName: shift.outlet.name,
+  startedAt: shift.startTime,
+  endedAt: shift.endTime,
+  isActive: shift.endTime === null,
+});

--- a/src/features/shifts/shift-model.ts
+++ b/src/features/shifts/shift-model.ts
@@ -1,0 +1,24 @@
+export type CreateShiftInput = {
+  staffId: string;
+  startedAt: string;
+};
+
+export type ShiftListQuery = {
+  page: number;
+  limit: number;
+  staffId?: string;
+  outletId?: string;
+  isActive?: boolean;
+};
+
+export type ShiftResponse = {
+  id: string;
+  staffId: string;
+  workerType: string | null;
+  workerName: string | null;
+  outletId: string;
+  outletName: string;
+  startedAt: Date;
+  endedAt: Date | null;
+  isActive: boolean;
+};

--- a/src/features/shifts/shift-service.ts
+++ b/src/features/shifts/shift-service.ts
@@ -1,0 +1,105 @@
+import { prisma } from '@/application/database';
+import type { Staff } from '@/generated/prisma/client';
+import { ResponseError } from '@/error/response-error';
+import { resolveManagedOutletId, toShiftResponse } from './shift-helper';
+import type { CreateShiftInput, ShiftListQuery } from './shift-model';
+
+const SHIFT_INCLUDE = {
+  staff: { include: { user: { select: { name: true } } } },
+  outlet: { select: { id: true, name: true } },
+} as const;
+
+export class ShiftService {
+  static async createShift(staff: Staff, data: CreateShiftInput) {
+    const worker = await prisma.staff.findUnique({
+      where: { id: data.staffId },
+      include: SHIFT_INCLUDE,
+    });
+
+    if (!worker || worker.role !== 'WORKER' || !worker.outletId) {
+      throw new ResponseError(404, 'Worker not found');
+    }
+
+    resolveManagedOutletId(staff, worker.outletId);
+
+    const activeShift = await prisma.shift.findFirst({
+      where: { staffId: worker.id, endTime: null },
+    });
+
+    if (activeShift) {
+      throw new ResponseError(409, 'Worker already has an active shift');
+    }
+
+    const shift = await prisma.shift.create({
+      data: {
+        staffId: worker.id,
+        outletId: worker.outletId,
+        startTime: new Date(data.startedAt),
+        endTime: null,
+      },
+      include: SHIFT_INCLUDE,
+    });
+
+    return toShiftResponse(shift);
+  }
+
+  static async getShifts(staff: Staff, query: ShiftListQuery) {
+    const outletId = resolveManagedOutletId(staff, query.outletId);
+    const where = {
+      ...(outletId ? { outletId } : {}),
+      ...(query.staffId ? { staffId: query.staffId } : {}),
+      ...(query.isActive === undefined
+        ? {}
+        : query.isActive
+          ? { endTime: null }
+          : { NOT: { endTime: null } }),
+    };
+    const skip = (query.page - 1) * query.limit;
+
+    const [shifts, total] = await prisma.$transaction([
+      prisma.shift.findMany({
+        where,
+        skip,
+        take: query.limit,
+        orderBy: { startTime: 'desc' },
+        include: SHIFT_INCLUDE,
+      }),
+      prisma.shift.count({ where }),
+    ]);
+
+    return {
+      data: shifts.map(toShiftResponse),
+      meta: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    };
+  }
+
+  static async endShift(staff: Staff, shiftId: string) {
+    const shift = await prisma.shift.findUnique({
+      where: { id: shiftId },
+      include: SHIFT_INCLUDE,
+    });
+
+    if (!shift) {
+      throw new ResponseError(404, 'Shift not found');
+    }
+
+    resolveManagedOutletId(staff, shift.outletId);
+
+    if (shift.endTime) {
+      throw new ResponseError(409, 'Shift has already ended');
+    }
+
+    const updatedShift = await prisma.shift.update({
+      where: { id: shiftId },
+      data: { endTime: new Date() },
+      include: SHIFT_INCLUDE,
+    });
+
+    return toShiftResponse(updatedShift);
+  }
+}

--- a/src/middleware/shift-middleware.ts
+++ b/src/middleware/shift-middleware.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@/application/database';
+import type { NextFunction, Response } from 'express';
+import type { UserRequest } from '@/types/user-request';
+
+export const requireActiveWorkerShift = async (
+  req: UserRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const activeShift = await prisma.shift.findFirst({
+      where: { staffId: req.staff!.id, endTime: null },
+    });
+
+    if (!activeShift) {
+      res.status(403).json({ errors: 'Worker is not on an active shift' });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -4,7 +4,7 @@ import {
   requireCustomerAuth,
   requireStaffRole,
 } from '@/middleware/auth-middleware';
-
+import { requireActiveWorkerShift } from '@/middleware/shift-middleware';
 import { UserController } from '@/features/users/user-controller';
 import { AdminUserController } from '@/features/admin-users/admin-user-controller';
 import { AdminOrderController } from '@/features/admin-orders/admin-order-controller';
@@ -14,168 +14,50 @@ import { BypassRequestController } from '@/features/bypass-requests/bypass-reque
 import { OrderController } from '@/features/orders/order-controller';
 import { WorkerOrderController } from '@/features/worker-orders/worker-order-controller';
 import { WorkerNotificationController } from '@/features/worker-notifications/worker-notification-controller';
+import { ShiftController } from '@/features/shifts/shift-controller';
 
 export const apiRouter = express.Router();
 
-// USER
 apiRouter.get('/users/me', requireAuth, UserController.getMe);
 
-// REGION
-apiRouter.get(
-  '/regions/provinces',
-  requireAuth,
-  RegionController.listProvinces,
-);
-apiRouter.get(
-  '/regions/cities/:provinceId',
-  requireAuth,
-  RegionController.listCities,
-);
+apiRouter.get('/regions/provinces', requireAuth, RegionController.listProvinces);
+apiRouter.get('/regions/cities/:provinceId', requireAuth, RegionController.listCities);
 apiRouter.get('/regions/geocode', requireAuth, RegionController.geocode);
 
-// ADDRESS
 apiRouter.get('/users/addresses', requireCustomerAuth, AddressController.list);
-apiRouter.post(
-  '/users/addresses',
-  requireCustomerAuth,
-  AddressController.create,
-);
-apiRouter.patch(
-  '/users/addresses/:id/primary',
-  requireCustomerAuth,
-  AddressController.setPrimary,
-);
-apiRouter.patch(
-  '/users/addresses/:id',
-  requireCustomerAuth,
-  AddressController.update,
-);
-apiRouter.delete(
-  '/users/addresses/:id',
-  requireCustomerAuth,
-  AddressController.remove,
-);
+apiRouter.post('/users/addresses', requireCustomerAuth, AddressController.create);
+apiRouter.patch('/users/addresses/:id/primary', requireCustomerAuth, AddressController.setPrimary);
+apiRouter.patch('/users/addresses/:id', requireCustomerAuth, AddressController.update);
+apiRouter.delete('/users/addresses/:id', requireCustomerAuth, AddressController.remove);
 
-// ADMIN
-apiRouter.get(
-  '/admin/dashboard',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  UserController.getDashboardStats,
-);
-apiRouter.get(
-  '/admin/users',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminUserController.getAdminUsers,
-);
-apiRouter.get(
-  '/admin/orders',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminOrderController.getAdminOrders,
-);
-apiRouter.get(
-  '/admin/orders/:id',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminOrderController.getAdminOrderDetail,
-);
-apiRouter.get(
-  '/admin/pickup-requests',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminOrderController.getAdminPickupRequests,
-);
-apiRouter.post(
-  '/admin/orders',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminOrderController.createAdminOrder,
-);
-apiRouter.post(
-  '/admin/users',
-  requireStaffRole('SUPER_ADMIN'),
-  AdminUserController.createAdminUser,
-);
-apiRouter.patch(
-  '/admin/users/:id',
-  requireStaffRole('SUPER_ADMIN'),
-  AdminUserController.updateAdminUser,
-);
-apiRouter.get(
-  '/admin/laundry-items',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  AdminOrderController.getLaundryItems,
-);
-apiRouter.delete(
-  '/admin/users/:id',
-  requireStaffRole('SUPER_ADMIN'),
-  AdminUserController.deleteAdminUser,
-);
+apiRouter.get('/admin/dashboard', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), UserController.getDashboardStats);
+apiRouter.get('/admin/users', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminUserController.getAdminUsers);
+apiRouter.get('/admin/orders', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getAdminOrders);
+apiRouter.get('/admin/orders/:id', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getAdminOrderDetail);
+apiRouter.get('/admin/pickup-requests', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getAdminPickupRequests);
+apiRouter.post('/admin/orders', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.createAdminOrder);
+apiRouter.post('/admin/users', requireStaffRole('SUPER_ADMIN'), AdminUserController.createAdminUser);
+apiRouter.patch('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.updateAdminUser);
+apiRouter.get('/admin/laundry-items', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), AdminOrderController.getLaundryItems);
+apiRouter.delete('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserController.deleteAdminUser);
 
-// BYPASS REQUEST
-apiRouter.post(
-  '/orders/:id/stations/:station/bypass',
-  requireStaffRole('WORKER'),
-  BypassRequestController.create,
-);
-apiRouter.get(
-  '/bypass-requests',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  BypassRequestController.getAll,
-);
-apiRouter.get(
-  '/bypass-requests/:id',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  BypassRequestController.getById,
-);
-apiRouter.patch(
-  '/bypass-requests/:id/approve',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  BypassRequestController.approve,
-);
-apiRouter.patch(
-  '/bypass-requests/:id/reject',
-  requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'),
-  BypassRequestController.reject,
-);
+apiRouter.post('/shifts', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.create);
+apiRouter.get('/shifts', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.list);
+apiRouter.patch('/shifts/:id/end', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.end);
 
-// ORDER
+apiRouter.post('/orders/:id/stations/:station/bypass', requireStaffRole('WORKER'), BypassRequestController.create);
+apiRouter.get('/bypass-requests', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), BypassRequestController.getAll);
+apiRouter.get('/bypass-requests/:id', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), BypassRequestController.getById);
+apiRouter.patch('/bypass-requests/:id/approve', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), BypassRequestController.approve);
+apiRouter.patch('/bypass-requests/:id/reject', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), BypassRequestController.reject);
+
 apiRouter.get('/orders', requireCustomerAuth, OrderController.listOrders);
-apiRouter.get(
-  '/orders/:id',
-  requireCustomerAuth,
-  OrderController.getOrderDetail,
-);
-apiRouter.post(
-  '/orders/:id/confirm',
-  requireCustomerAuth,
-  OrderController.confirmReceipt,
-);
+apiRouter.get('/orders/:id', requireCustomerAuth, OrderController.getOrderDetail);
+apiRouter.post('/orders/:id/confirm', requireCustomerAuth, OrderController.confirmReceipt);
 
-// WORKER
-apiRouter.get(
-  '/worker/history',
-  requireStaffRole('WORKER'),
-  WorkerOrderController.getHistory,
-);
-apiRouter.get(
-  '/worker/orders',
-  requireStaffRole('WORKER'),
-  WorkerOrderController.getOrders,
-);
-apiRouter.get(
-  '/worker/orders/:id',
-  requireStaffRole('WORKER'),
-  WorkerOrderController.getOrderDetail,
-);
-apiRouter.post(
-  '/worker/orders/:id/process',
-  requireStaffRole('WORKER'),
-  WorkerOrderController.processOrder,
-);
-apiRouter.post(
-  '/worker/orders/:id/bypass-request',
-  requireStaffRole('WORKER'),
-  BypassRequestController.createWorker,
-);
-apiRouter.get(
-  '/worker/notifications/stream',
-  requireStaffRole('WORKER'),
-  WorkerNotificationController.stream,
-);
+apiRouter.get('/worker/history', requireStaffRole('WORKER'), WorkerOrderController.getHistory);
+apiRouter.get('/worker/orders', requireStaffRole('WORKER'), WorkerOrderController.getOrders);
+apiRouter.get('/worker/orders/:id', requireStaffRole('WORKER'), WorkerOrderController.getOrderDetail);
+apiRouter.post('/worker/orders/:id/process', requireStaffRole('WORKER'), requireActiveWorkerShift, WorkerOrderController.processOrder);
+apiRouter.post('/worker/orders/:id/bypass-request', requireStaffRole('WORKER'), requireActiveWorkerShift, BypassRequestController.createWorker);
+apiRouter.get('/worker/notifications/stream', requireStaffRole('WORKER'), WorkerNotificationController.stream);

--- a/src/validations/shift-validation.ts
+++ b/src/validations/shift-validation.ts
@@ -1,0 +1,21 @@
+import { z, type ZodType } from 'zod';
+import type { CreateShiftInput, ShiftListQuery } from '@/features/shifts/shift-model';
+
+const booleanQuery = z.enum(['true', 'false']).transform((value) => value === 'true');
+
+export class ShiftValidation {
+  static readonly ID_PARAM: ZodType<string> = z.uuid();
+
+  static readonly CREATE: ZodType<CreateShiftInput> = z.object({
+    staffId: z.uuid(),
+    startedAt: z.string().datetime(),
+  });
+
+  static readonly LIST: ZodType<ShiftListQuery> = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    staffId: z.uuid().optional(),
+    outletId: z.uuid().optional(),
+    isActive: booleanQuery.optional(),
+  });
+}

--- a/tests/integration/bypass-routes.test.ts
+++ b/tests/integration/bypass-routes.test.ts
@@ -12,6 +12,7 @@ jest.mock('@/application/database', () => ({
   prisma: {
     user: { findUnique: jest.fn() },
     staff: { findUnique: jest.fn() },
+    shift: { findFirst: jest.fn() },
     stationRecord: { findUnique: jest.fn(), update: jest.fn() },
     orderItem: { findMany: jest.fn() },
     stationItem: { deleteMany: jest.fn(), createMany: jest.fn() },
@@ -47,6 +48,7 @@ const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
 describe('Bypass Routes Integration Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue({ id: 'shift-1' });
     (prisma.$transaction as jest.Mock).mockImplementation(
       (callback: (tx: any) => Promise<any>) =>
         callback({

--- a/tests/integration/shift-routes.test.ts
+++ b/tests/integration/shift-routes.test.ts
@@ -1,0 +1,123 @@
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((headers: Record<string, string | string[] | undefined>) => headers),
+  toNodeHandler: jest.fn(() => (_req: any, res: any) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    staff: { findUnique: jest.fn(), findFirst: jest.fn() },
+    shift: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    stationRecord: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn() },
+    orderItem: { findMany: jest.fn() },
+    stationItem: { deleteMany: jest.fn(), createMany: jest.fn() },
+    order: { update: jest.fn() },
+    delivery: { create: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({ auth: { api: { getSession: jest.fn() } } }));
+jest.mock('@/features/worker-notifications/worker-notification-service', () => ({ WorkerNotificationService: { publishOrderArrival: jest.fn() } }));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+
+const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('Shift Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.$transaction as jest.Mock).mockResolvedValue([[], 0]);
+  });
+
+  const mockAdmin = (role: 'SUPER_ADMIN' | 'OUTLET_ADMIN' = 'OUTLET_ADMIN') => {
+    const mockUser = { id: 'user-admin', email: 'admin@example.com' };
+    const mockStaff = { id: 'staff-admin', role, isActive: true, outletId: 'outlet-1' };
+    (auth.api.getSession as jest.Mock).mockResolvedValue({ user: mockUser, session: { id: 's', expiresAt: new Date() } });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  const mockWorker = () => {
+    const mockUser = { id: 'user-worker', email: 'worker@example.com' };
+    const mockStaff = { id: 'staff-worker', role: 'WORKER', isActive: true, outletId: 'outlet-1', workerType: 'WASHING' };
+    (auth.api.getSession as jest.Mock).mockResolvedValue({ user: mockUser, session: { id: 's', expiresAt: new Date() } });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
+  };
+
+  it('creates a shift', async () => {
+    mockAdmin();
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValueOnce({ id: 'staff-admin', role: 'OUTLET_ADMIN', isActive: true, outletId: 'outlet-1' });
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: VALID_UUID,
+      role: 'WORKER',
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      user: { name: 'Wash Worker' },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.shift.create as jest.Mock).mockResolvedValue({
+      id: 'shift-1', staffId: VALID_UUID, startTime: new Date('2026-04-20T08:00:00.000Z'), endTime: null,
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } }, outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+
+    const response = await request(app).post('/api/v1/shifts').send({ staffId: VALID_UUID, startedAt: '2026-04-20T08:00:00.000Z' });
+
+    expect(response.status).toBe(201);
+    expect(response.body.data.isActive).toBe(true);
+  });
+
+  it('lists shifts with meta', async () => {
+    mockAdmin('SUPER_ADMIN');
+    (prisma.$transaction as jest.Mock).mockResolvedValue([[{
+      id: 'shift-1', staffId: VALID_UUID, startTime: new Date('2026-04-20T08:00:00.000Z'), endTime: null,
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } }, outlet: { id: 'outlet-1', name: 'Outlet A' },
+    }], 1]);
+
+    const response = await request(app).get('/api/v1/shifts').query({ isActive: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.meta.total).toBe(1);
+  });
+
+  it('ends a shift', async () => {
+    mockAdmin();
+    (prisma.shift.findUnique as jest.Mock).mockResolvedValue({
+      id: VALID_UUID, outletId: 'outlet-1', staffId: 'worker-1', startTime: new Date('2026-04-20T08:00:00.000Z'), endTime: null,
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } }, outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+    (prisma.shift.update as jest.Mock).mockResolvedValue({
+      id: VALID_UUID, outletId: 'outlet-1', staffId: 'worker-1', startTime: new Date('2026-04-20T08:00:00.000Z'), endTime: new Date('2026-04-20T17:00:00.000Z'),
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } }, outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+
+    const response = await request(app).patch(`/api/v1/shifts/${VALID_UUID}/end`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.isActive).toBe(false);
+  });
+
+  it('blocks worker processing when no active shift exists', async () => {
+    mockWorker();
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app)
+      .post(`/api/v1/worker/orders/${VALID_UUID}/process`)
+      .send({ items: [{ laundryItemId: VALID_UUID, quantity: 1 }] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.errors).toBe('Worker is not on an active shift');
+  });
+});

--- a/tests/integration/worker-order-routes.test.ts
+++ b/tests/integration/worker-order-routes.test.ts
@@ -12,6 +12,7 @@ jest.mock('@/application/database', () => ({
     staff: { findUnique: jest.fn(), findFirst: jest.fn() },
     stationRecord: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     orderItem: { findMany: jest.fn() },
+    shift: { findFirst: jest.fn() },
   },
 }));
 
@@ -37,6 +38,7 @@ describe('Worker Order Routes', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue({ id: 'shift-1' });
   });
 
   const mockWorkerAuth = (overrides: Partial<any> = {}) => {

--- a/tests/unit/shift-service.test.ts
+++ b/tests/unit/shift-service.test.ts
@@ -1,0 +1,134 @@
+jest.mock('@/application/database', () => ({
+  prisma: {
+    shift: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    staff: { findUnique: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import { ShiftService } from '@/features/shifts/shift-service';
+
+describe('ShiftService', () => {
+  const superAdmin = { id: 'staff-super', role: 'SUPER_ADMIN', outletId: null } as any;
+  const outletAdmin = { id: 'staff-admin', role: 'OUTLET_ADMIN', outletId: 'outlet-1' } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a worker shift', async () => {
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+      id: 'worker-1',
+      role: 'WORKER',
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      user: { name: 'Wash Worker' },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.shift.create as jest.Mock).mockResolvedValue({
+      id: 'shift-1',
+      staffId: 'worker-1',
+      startTime: new Date('2026-04-20T08:00:00.000Z'),
+      endTime: null,
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+
+    const result = await ShiftService.createShift(outletAdmin, {
+      staffId: 'worker-1',
+      startedAt: '2026-04-20T08:00:00.000Z',
+    });
+
+    expect(result.isActive).toBe(true);
+  });
+
+  it('blocks duplicate active shifts', async () => {
+    (prisma.staff.findUnique as jest.Mock).mockResolvedValue({
+      id: 'worker-1',
+      role: 'WORKER',
+      outletId: 'outlet-1',
+      workerType: 'WASHING',
+      user: { name: 'Wash Worker' },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue({ id: 'shift-active' });
+
+    await expect(
+      ShiftService.createShift(outletAdmin, {
+        staffId: 'worker-1',
+        startedAt: '2026-04-20T08:00:00.000Z',
+      }),
+    ).rejects.toThrow(new ResponseError(409, 'Worker already has an active shift'));
+  });
+
+  it('lists shifts with filters', async () => {
+    (prisma.$transaction as jest.Mock).mockResolvedValue([
+      [{
+        id: 'shift-1',
+        staffId: 'worker-1',
+        startTime: new Date('2026-04-20T08:00:00.000Z'),
+        endTime: null,
+        staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } },
+        outlet: { id: 'outlet-1', name: 'Outlet A' },
+      }],
+      1,
+    ]);
+
+    const result = await ShiftService.getShifts(outletAdmin, {
+      page: 1,
+      limit: 10,
+      isActive: true,
+    });
+
+    expect(result.meta.total).toBe(1);
+    expect(result.data[0].isActive).toBe(true);
+  });
+
+  it('allows super admin outlet filtering', async () => {
+    (prisma.$transaction as jest.Mock).mockResolvedValue([[], 0]);
+
+    await ShiftService.getShifts(superAdmin, {
+      page: 1,
+      limit: 10,
+      outletId: 'outlet-2',
+    });
+
+    const findManyArgs = (prisma.shift.findMany as jest.Mock).mock.calls[0][0];
+    expect(findManyArgs.where.outletId).toBe('outlet-2');
+  });
+
+  it('ends an active shift', async () => {
+    (prisma.shift.findUnique as jest.Mock).mockResolvedValue({
+      id: 'shift-1',
+      outletId: 'outlet-1',
+      staffId: 'worker-1',
+      startTime: new Date('2026-04-20T08:00:00.000Z'),
+      endTime: null,
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+    (prisma.shift.update as jest.Mock).mockResolvedValue({
+      id: 'shift-1',
+      outletId: 'outlet-1',
+      staffId: 'worker-1',
+      startTime: new Date('2026-04-20T08:00:00.000Z'),
+      endTime: new Date('2026-04-20T17:00:00.000Z'),
+      staff: { workerType: 'WASHING', user: { name: 'Wash Worker' } },
+      outlet: { id: 'outlet-1', name: 'Outlet A' },
+    });
+
+    const result = await ShiftService.endShift(outletAdmin, 'shift-1');
+
+    expect(result.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
### What changed
- added backend shift management endpoints for PCS-153:
  - `POST /api/v1/shifts`
  - `GET /api/v1/shifts`
  - `PATCH /api/v1/shifts/:id/end`
- added shift validation, service, controller, and test coverage
- added role-scoped shift management:
  - `SUPER_ADMIN` can manage shifts across outlets
  - `OUTLET_ADMIN` can only manage shifts in their own outlet
- enforced one active shift per worker at a time
- added active-shift middleware for worker station processing
- applied the active-shift guard to:
  - `POST /api/v1/worker/orders/:id/process`
  - `POST /api/v1/worker/orders/:id/bypass-request`
- added Prisma schema update and migration so `Shift.endTime` is nullable for active/open shifts

### Why
- implements backend part of PCS-153 Shift Management — Admin
- covers PCS-173 until PCS-176
- ensures workers must be on an active shift before processing or bypassing station work

### How to test
1. run `npx prisma generate`
2. run `npm run build`
3. run:
   - `npx jest tests/unit/shift-service.test.ts --runInBand`
   - `npx jest tests/integration/shift-routes.test.ts --runInBand`
   - `npx jest tests/integration/worker-order-routes.test.ts --runInBand`
   - `npx jest tests/integration/bypass-routes.test.ts --runInBand`
4. authenticate as `OUTLET_ADMIN` or `SUPER_ADMIN`
5. verify:
   - `POST /api/v1/shifts` creates a worker shift
   - duplicate active shifts for the same worker are rejected
   - `GET /api/v1/shifts` returns paginated shifts with filters
   - `PATCH /api/v1/shifts/:id/end` closes an active shift
6. authenticate as `WORKER`
7. call:
   - `POST /api/v1/worker/orders/:id/process`
   - `POST /api/v1/worker/orders/:id/bypass-request`
8. verify a worker without an active shift receives `403 Worker is not on an active shift`

### Notes
- this PR adds a dedicated shift management backend flow rather than embedding shift logic directly into worker order services
- `Shift.endTime` is now nullable so an open shift can be represented with `endTime = null`
- an unrelated local untracked file was intentionally excluded from the commit
