### PR TITLE
feat: add laundry items endpoint and idempotent seed

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -40,13 +40,15 @@ const LAUNDRY_ITEMS = [
 ];
 
 const seedLaundryItems = async () => {
-  const count = await prisma.laundryItem.count();
-  if (count > 0) {
-    console.log(`Skipping laundry items — ${count} already exist.`);
-    return;
-  }
-
-  await prisma.laundryItem.createMany({ data: LAUNDRY_ITEMS });
+  await Promise.all(
+    LAUNDRY_ITEMS.map((item) =>
+      prisma.laundryItem.upsert({
+        where: { slug: item.slug },
+        update: { name: item.name, isActive: true },
+        create: { name: item.name, slug: item.slug, isActive: true },
+      }),
+    ),
+  );
   console.log(`Seeded ${LAUNDRY_ITEMS.length} laundry items.`);
 };
 
@@ -56,7 +58,7 @@ const seedSuperAdmin = async () => {
   });
 
   if (existing) {
-    console.log('Skipping super admin — already exists.');
+    console.log('Skipping super admin because it already exists.');
     return;
   }
 
@@ -85,7 +87,6 @@ const seedSuperAdmin = async () => {
       },
     });
 
-    // better-auth credential account format
     await tx.account.create({
       data: {
         id: accountId,

--- a/src/features/laundry-items/laundry-item-controller.ts
+++ b/src/features/laundry-items/laundry-item-controller.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express';
+import { LaundryItemService } from './laundry-item-service';
+
+export class LaundryItemController {
+  static async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const items = await LaundryItemService.listActive();
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Laundry items retrieved',
+        data: items,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/laundry-items/laundry-item-model.ts
+++ b/src/features/laundry-items/laundry-item-model.ts
@@ -1,0 +1,5 @@
+export type LaundryItemListItem = {
+  id: string;
+  name: string;
+  slug: string;
+};

--- a/src/features/laundry-items/laundry-item-service.ts
+++ b/src/features/laundry-items/laundry-item-service.ts
@@ -1,0 +1,12 @@
+import { prisma } from '@/application/database';
+import { LaundryItemListItem } from './laundry-item-model';
+
+export class LaundryItemService {
+  static async listActive(): Promise<LaundryItemListItem[]> {
+    return prisma.laundryItem.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true, slug: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -17,6 +17,7 @@ import { WorkerOrderController } from '@/features/worker-orders/worker-order-con
 import { WorkerNotificationController } from '@/features/worker-notifications/worker-notification-controller';
 import { PickupRequestController } from '@/features/pickup-requests/pickup-request-controller';
 import { PaymentController } from '@/features/payments/payment-controller';
+import { LaundryItemController } from '@/features/laundry-items/laundry-item-controller';
 
 export const apiRouter = express.Router();
 
@@ -36,6 +37,7 @@ apiRouter.get(
 );
 apiRouter.get('/regions/geocode', requireAuth, RegionController.geocode);
 apiRouter.get('/regions/reverse-geocode', requireAuth, RegionController.reverseGeocode);
+apiRouter.get('/laundry-items', requireAuth, LaundryItemController.list);
 
 // ADDRESS
 apiRouter.get('/users/addresses', requireCustomerAuth, AddressController.list);

--- a/tests/integration/laundry-item-routes.test.ts
+++ b/tests/integration/laundry-item-routes.test.ts
@@ -1,0 +1,51 @@
+import type { Request, Response } from 'express';
+
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((headers: Record<string, string | string[] | undefined>) => headers),
+  toNodeHandler: jest.fn(() => (_req: Request, res: Response) => res.json({ ok: true })),
+}));
+
+jest.mock('@/application/database', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    laundryItem: { findMany: jest.fn() },
+  },
+}));
+
+jest.mock('@/utils/auth', () => ({
+  auth: {
+    api: { getSession: jest.fn() },
+  },
+}));
+
+import request from 'supertest';
+import { app } from '@/application/app';
+import { prisma } from '@/application/database';
+import { auth } from '@/utils/auth';
+
+describe('Laundry Item Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    (auth.api.getSession as unknown as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/v1/laundry-items');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns active laundry items for authenticated users', async () => {
+    const mockUser = { id: 'user-1', email: 'john@example.com' };
+    const mockItems = [{ id: '1', name: 'Shirt', slug: 'shirt' }];
+    (auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: mockUser, session: 'token' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.laundryItem.findMany as jest.Mock).mockResolvedValue(mockItems);
+
+    const response = await request(app).get('/api/v1/laundry-items');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual(mockItems);
+  });
+});

--- a/tests/unit/laundry-item-service.test.ts
+++ b/tests/unit/laundry-item-service.test.ts
@@ -1,0 +1,26 @@
+jest.mock('@/application/database', () => ({
+  prisma: {
+    laundryItem: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from '@/application/database';
+import { LaundryItemService } from '@/features/laundry-items/laundry-item-service';
+
+describe('LaundryItemService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists active laundry items ordered by name', async () => {
+    const items = [{ id: '1', name: 'Shirt', slug: 'shirt' }];
+    (prisma.laundryItem.findMany as jest.Mock).mockResolvedValue(items);
+
+    await expect(LaundryItemService.listActive()).resolves.toEqual(items);
+    expect(prisma.laundryItem.findMany).toHaveBeenCalledWith({
+      where: { isActive: true },
+      select: { id: true, name: true, slug: true },
+      orderBy: { name: 'asc' },
+    });
+  });
+});


### PR DESCRIPTION
### What changed
- added `GET /api/v1/laundry-items` endpoint for authenticated users
- added dedicated laundry-items backend feature:
  - model
  - service
  - controller
- added route integration in `api.ts`
- updated `prisma/seed.ts` to seed laundry items idempotently via `upsert`
- ensured seeded laundry items stay active (`isActive: true`)
- added unit and integration test coverage for laundry-items endpoint

### Why
- implements backend part of PCS-156 Laundry Items API Integration
- covers:
  - PCS-178 `GET /api/v1/laundry-items`
  - PCS-179 seed 28 laundry items via `prisma/seed.ts`
- provides shared master laundry item list for admin order creation and worker processing forms

### How to test
1. run `npm run build`
2. run:
   - `npx jest tests/unit/laundry-item-service.test.ts --runInBand`
   - `npx jest tests/integration/laundry-item-routes.test.ts --runInBand`
3. authenticate as any valid role
4. call `GET /api/v1/laundry-items`
5. verify:
   - only active items are returned
   - payload includes `id`, `name`, `slug`
   - items are sorted alphabetically by `name`
6. run `npx prisma db seed` and verify no duplicate laundry items are created on repeated runs

### Notes
- this endpoint intentionally has no pagination (fixed small master list)
- unrelated local changes were intentionally excluded from this commit
