### PR TITLE
feat: notify worker and reset station on bypass reject

### DIFF
--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -132,15 +132,28 @@ export class BypassRequestService {
     bypassId: string,
     password: string,
   ) {
-    return prisma.$transaction(async (tx) => {
+    const result = await prisma.$transaction(async (tx) => {
       const bypass = await loadAndVerifyBypass(tx, admin, bypassId, password);
       const updated = await tx.bypassRequest.update({
         where: { id: bypassId },
         data: { status: BypassStatus.REJECTED, adminId: admin.staffId, resolvedAt: new Date() },
       });
       await tx.stationRecord.update({ where: { id: bypass.stationRecordId }, data: { status: StationStatus.IN_PROGRESS } });
-      return toRejectBypassResponse(updated);
+      return {
+        orderId: bypass.stationRecord.order.id,
+        outletId: bypass.stationRecord.order.outletId,
+        orderStatus: bypass.stationRecord.order.status,
+        response: toRejectBypassResponse(updated),
+      };
     });
+
+    WorkerNotificationService.publishOrderArrival({
+      orderId: result.orderId,
+      outletId: result.outletId,
+      orderStatus: result.orderStatus,
+    });
+
+    return result.response;
   }
 
   static async getById(

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -648,6 +648,11 @@ describe('BypassRequestService', () => {
         where: { id: 'sr-1' },
         data: { status: 'IN_PROGRESS' },
       });
+      expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
+        orderId: 'ord-1',
+        outletId: 'outlet-1',
+        orderStatus: 'LAUNDRY_BEING_WASHED',
+      });
     });
   });
 


### PR DESCRIPTION
## What changed
- implemented `PCS-203` for `PATCH /api/v1/bypass-requests/:id/reject`
- kept existing reject behavior:
  - set bypass request status to `REJECTED`
  - revert related `StationRecord.status` to `IN_PROGRESS`
- added worker notification publish after successful reject transaction:
  - call `WorkerNotificationService.publishOrderArrival(...)`
  - use order context from bypass relation (`orderId`, `outletId`, `orderStatus`)

## Why
- follow business rule for rejected bypass:
  - worker must re-enter correct quantities
  - worker should be notified so station flow can continue from `IN_PROGRESS`

## Files changed
- `src/features/bypass-requests/bypass-request-service.ts`
- `tests/unit/bypass-request-service.test.ts`

## How to test
1. run:
   - `npx jest tests/unit/bypass-request-service.test.ts --runInBand`
2. verify reject behavior:
   - call `PATCH /api/v1/bypass-requests/:id/reject` with valid outlet admin + password
   - confirm bypass status becomes `REJECTED`
   - confirm related station record status becomes `IN_PROGRESS`
   - confirm worker notification publish is triggered in service test

## Notes
- `tests/integration/bypass-routes.test.ts` currently has existing failures on error-envelope assertions (`response.body.errors`) and is not caused by this PCS-203 logic update.
