### PR TITLE
chore: sync development into main

### DIFF
--- a/src/features/admin-orders/admin-order-service.ts
+++ b/src/features/admin-orders/admin-order-service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/application/database'
 import { ResponseError } from '@/error/response-error'
-import { OrderStatus } from '@/generated/prisma/client'
+import { OrderStatus, StationStatus, StationType } from '@/generated/prisma/client'
 import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service'
 import { v4 as uuid } from 'uuid'
 import { CreateAdminOrderInput, GetAdminOrdersQuery, LaundryItemResponse } from './admin-order-model'
@@ -172,8 +172,8 @@ export class AdminOrderService {
 
     const orderId = uuid()
 
-    // Atomic operation: create Order and all OrderItems in one transaction.
-    // If any item creation fails, the entire order is rolled back.
+    // Atomic operation: create Order, initial station record, and all OrderItems in one transaction.
+    // If any step fails, the entire order is rolled back.
     const [order] = await prisma.$transaction([
       prisma.order.create({
         data: {
@@ -186,6 +186,13 @@ export class AdminOrderService {
           totalPrice,
           status: OrderStatus.LAUNDRY_BEING_WASHED,
         }
+      }),
+      prisma.stationRecord.create({
+        data: {
+          orderId,
+          station: StationType.WASHING,
+          status: StationStatus.IN_PROGRESS,
+        },
       }),
       ...data.items.map((item) =>
         prisma.orderItem.create({

--- a/tests/unit/admin-order-service.test.ts
+++ b/tests/unit/admin-order-service.test.ts
@@ -2,6 +2,7 @@ jest.mock('@/application/database', () => ({
   prisma: {
     order: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), count: jest.fn() },
     orderItem: { create: jest.fn() },
+    stationRecord: { create: jest.fn() },
     pickupRequest: { findMany: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
     $transaction: jest.fn(),
   },
@@ -294,12 +295,13 @@ describe('AdminOrderService', () => {
     it('should pass transaction array of length 1 + items.length', async () => {
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
       (prisma.order.create as jest.Mock).mockResolvedValue(mockOrder);
+      (prisma.stationRecord.create as jest.Mock).mockResolvedValue({ id: 'sr-1' });
       (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
 
       await AdminOrderService.createAdminOrder(superAdmin, validInput);
 
       const txArgs = (prisma.$transaction as jest.Mock).mock.calls[0][0];
-      expect(txArgs).toHaveLength(1 + validInput.items.length);
+      expect(txArgs).toHaveLength(2 + validInput.items.length);
     });
 
     it('should set created order status to LAUNDRY_BEING_WASHED', async () => {
@@ -319,6 +321,7 @@ describe('AdminOrderService', () => {
     it('should publish a worker arrival notification after order creation', async () => {
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
       (prisma.order.create as jest.Mock).mockResolvedValue(mockOrder);
+      (prisma.stationRecord.create as jest.Mock).mockResolvedValue({ id: 'sr-1' });
       (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
 
       await AdminOrderService.createAdminOrder(superAdmin, validInput);
@@ -327,6 +330,24 @@ describe('AdminOrderService', () => {
         orderId: 'order-new',
         outletId: 'outlet-1',
         orderStatus: 'LAUNDRY_BEING_WASHED',
+      });
+    });
+
+    it('should create initial WASHING station record in progress', async () => {
+      (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
+      (prisma.order.create as jest.Mock).mockResolvedValue(mockOrder);
+      (prisma.stationRecord.create as jest.Mock).mockResolvedValue({ id: 'sr-1' });
+      (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
+
+      await AdminOrderService.createAdminOrder(superAdmin, validInput);
+
+      const createdOrderId = (prisma.order.create as jest.Mock).mock.calls[0][0].data.id;
+      expect(prisma.stationRecord.create).toHaveBeenCalledWith({
+        data: {
+          orderId: createdOrderId,
+          station: 'WASHING',
+          status: 'IN_PROGRESS',
+        },
       });
     });
 
@@ -377,6 +398,7 @@ describe('AdminOrderService', () => {
         outletId: 'outlet-other',
         status: 'LAUNDRY_BEING_WASHED',
       });
+      (prisma.stationRecord.create as jest.Mock).mockResolvedValue({ id: 'sr-1' });
       (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
 
       const result = await AdminOrderService.createAdminOrder(superAdmin, validInput);


### PR DESCRIPTION
## What changed
- sync latest backend changes from `development` into `main`
- includes the recent worker queue fix where admin order creation now creates the initial `WASHING` station record
- keeps `main` aligned with the current tested development flow

## Why
- `development` is ahead of `main`
- this PR is needed so the latest backend fixes are available on the main branch for final testing and demo

## Included highlights
- worker flow and bypass flow updates from previous merged work
- shift management backend updates
- laundry item integration updates
- initial worker station record creation on admin order creation

## Notes
- previous `development -> main` PR was already merged, so this needs a new PR instead of reusing the old one
- frontend does not need the same action right now because `main` is already ahead of `development`
