### PR TITLE
feat: implement complaint filing and management

### DIFF
--- a/docs/complaints.md
+++ b/docs/complaints.md
@@ -15,7 +15,7 @@ All endpoints are under `/api/v1/complaints`.
 
 ## POST /api/v1/complaints
 
-Customer files a complaint about a completed order.
+Customer files a complaint about a delivered or completed order.
 
 **Access:** `CUSTOMER`
 
@@ -64,7 +64,7 @@ Customer files a complaint about a completed order.
 ```
 
 **Notes:**
-- Complaints can only be filed when `Order.status === 'COMPLETED'`.
+- Complaints can only be filed when `Order.status` is `LAUNDRY_DELIVERED_TO_CUSTOMER` or `COMPLETED`.
 - One complaint per order — duplicate submissions are rejected with `409`.
 - `description` is required and must be non-empty.
 
@@ -88,6 +88,7 @@ List complaints with server-side pagination and filtering.
 | `limit` | number | `10` | Items per page |
 | `status` | string | — | Filter by status: `OPEN`, `IN_REVIEW`, `RESOLVED` |
 | `outletId` | string | — | Filter by outlet (SUPER_ADMIN only) |
+| `orderId` | string (UUID) | — | Filter by specific order (CUSTOMER only) |
 | `sortBy` | string | `createdAt` | Sort field |
 | `order` | string | `desc` | `asc` or `desc` |
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["src"],
   "ext": ".ts,.js",
-  "exec": "ts-node ./src/main.ts"
+  "exec": "ts-node -r tsconfig-paths/register ./src/main.ts"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "build": "tsc && tsc-alias",
     "start": "node dist/main.js",
-    "dev": "ts-node -r tsconfig-paths/register ./src/main.ts"
+    "dev": "ts-node -r tsconfig-paths/register ./src/main.ts",
+    "dev:watch": "nodemon"
   },
   "prisma": {
     "seed": "ts-node --transpile-only -r tsconfig-paths/register prisma/seed.ts"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -310,6 +310,7 @@ model Complaint {
   description String
   status      ComplaintStatus @default(OPEN)
   createdAt   DateTime        @default(now()) @map("created_at")
+  updatedAt   DateTime        @updatedAt      @map("updated_at")
   customer    User            @relation(fields: [customerId], references: [id])
   order       Order           @relation(fields: [orderId], references: [id])
 

--- a/src/features/complaints/complaint-controller.ts
+++ b/src/features/complaints/complaint-controller.ts
@@ -1,0 +1,68 @@
+import { Response, NextFunction } from 'express';
+import { ComplaintService } from './complaint-service';
+import { Validation } from '@/validations/validation';
+import { ComplaintValidation } from '@/validations/complaint-validation';
+import { UserRequest } from '@/types/user-request';
+
+export class ComplaintController {
+  static async create(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const body = Validation.validate(ComplaintValidation.CREATE, req.body);
+      const result = await ComplaintService.create(req.user!.id, body);
+      res.status(201).json({ status: 'success', message: 'Complaint submitted', data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async list(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const query = Validation.validate(ComplaintValidation.LIST, req.query);
+      const result = await ComplaintService.list(
+        req.staff?.role,
+        req.user!.id,
+        req.staff?.outletId,
+        query,
+      );
+      res.status(200).json({
+        status: 'success',
+        message: 'Complaints retrieved',
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getById(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const complaintId = Validation.validate(ComplaintValidation.ID_PARAM, req.params.id);
+      const result = await ComplaintService.getById(
+        req.staff?.role,
+        req.user!.id,
+        req.staff?.outletId,
+        complaintId,
+      );
+      res.status(200).json({ status: 'success', message: 'Complaint retrieved', data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async updateStatus(req: UserRequest, res: Response, next: NextFunction) {
+    try {
+      const complaintId = Validation.validate(ComplaintValidation.ID_PARAM, req.params.id);
+      const body = Validation.validate(ComplaintValidation.UPDATE_STATUS, req.body);
+      const result = await ComplaintService.updateStatus(
+        req.staff!.role,
+        req.staff!.outletId,
+        complaintId,
+        body,
+      );
+      res.status(200).json({ status: 'success', message: 'Complaint status updated', data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/features/complaints/complaint-model.ts
+++ b/src/features/complaints/complaint-model.ts
@@ -1,0 +1,110 @@
+import type { ComplaintStatus, Prisma } from '@/generated/prisma/client';
+export type { ComplaintStatus } from '@/generated/prisma/client';
+
+export type CreateComplaintInput = {
+  orderId: string;
+  description: string;
+};
+
+export type UpdateComplaintStatusInput = {
+  status: 'IN_REVIEW' | 'RESOLVED';
+};
+
+export type ComplaintListQuery = {
+  page: number;
+  limit: number;
+  status?: ComplaintStatus;
+  outletId?: string;
+  orderId?: string;
+  sortBy: 'createdAt' | 'status';
+  order: 'asc' | 'desc';
+};
+
+export type ComplaintResponse = {
+  id: string;
+  orderId: string;
+  customerId: string;
+  description: string;
+  status: ComplaintStatus;
+  createdAt: Date;
+};
+
+export type ComplaintListItem = {
+  id: string;
+  orderId: string;
+  customerName: string;
+  outletName: string;
+  description: string;
+  status: ComplaintStatus;
+  createdAt: Date;
+};
+
+export type ComplaintDetailResponse = {
+  id: string;
+  orderId: string;
+  customerId: string;
+  customerName: string;
+  outletName: string;
+  description: string;
+  status: ComplaintStatus;
+  createdAt: Date;
+};
+
+export type ComplaintStatusUpdateResponse = {
+  id: string;
+  status: ComplaintStatus;
+  updatedAt: Date;
+};
+
+type ComplaintWithCreate = Prisma.ComplaintGetPayload<Record<string, never>>;
+
+type ComplaintWithRelations = Prisma.ComplaintGetPayload<{
+  include: {
+    customer: true;
+    order: { include: { outlet: true } };
+  };
+}>;
+
+export function toComplaintResponse(complaint: ComplaintWithCreate): ComplaintResponse {
+  return {
+    id: complaint.id,
+    orderId: complaint.orderId,
+    customerId: complaint.customerId,
+    description: complaint.description,
+    status: complaint.status,
+    createdAt: complaint.createdAt,
+  };
+}
+
+export function toComplaintListItem(complaint: ComplaintWithRelations): ComplaintListItem {
+  return {
+    id: complaint.id,
+    orderId: complaint.orderId,
+    customerName: complaint.customer.name ?? '',
+    outletName: complaint.order.outlet.name,
+    description: complaint.description,
+    status: complaint.status,
+    createdAt: complaint.createdAt,
+  };
+}
+
+export function toComplaintDetail(complaint: ComplaintWithRelations): ComplaintDetailResponse {
+  return {
+    id: complaint.id,
+    orderId: complaint.orderId,
+    customerId: complaint.customerId,
+    customerName: complaint.customer.name ?? '',
+    outletName: complaint.order.outlet.name,
+    description: complaint.description,
+    status: complaint.status,
+    createdAt: complaint.createdAt,
+  };
+}
+
+export function toComplaintStatusUpdate(complaint: ComplaintWithCreate): ComplaintStatusUpdateResponse {
+  return {
+    id: complaint.id,
+    status: complaint.status,
+    updatedAt: complaint.updatedAt,
+  };
+}

--- a/src/features/complaints/complaint-service.ts
+++ b/src/features/complaints/complaint-service.ts
@@ -1,0 +1,160 @@
+import { prisma } from '@/application/database';
+import { ResponseError } from '@/error/response-error';
+import type {
+  ComplaintListQuery,
+  ComplaintStatus,
+  CreateComplaintInput,
+  UpdateComplaintStatusInput,
+} from './complaint-model';
+import {
+  toComplaintDetail,
+  toComplaintListItem,
+  toComplaintResponse,
+  toComplaintStatusUpdate,
+} from './complaint-model';
+
+const COMPLAINT_RELATIONS = {
+  customer: true,
+  order: { include: { outlet: true } },
+} as const;
+
+function buildListWhere(
+  role: string | undefined,
+  userId: string,
+  staffOutletId: string | null | undefined,
+  query: ComplaintListQuery,
+) {
+  const where: Record<string, unknown> = {};
+
+  if (!role) {
+    where.customerId = userId;
+  } else if (role === 'OUTLET_ADMIN') {
+    where.order = { outletId: staffOutletId };
+  } else if (role === 'SUPER_ADMIN' && query.outletId) {
+    where.order = { outletId: query.outletId };
+  }
+
+  if (query.status) where.status = query.status;
+  if (query.orderId) where.orderId = query.orderId;
+
+  return where;
+}
+
+export class ComplaintService {
+  static async create(customerId: string, data: CreateComplaintInput) {
+    const order = await prisma.order.findFirst({
+      where: { id: data.orderId, pickupRequest: { customerId } },
+    });
+    if (!order) throw new ResponseError(404, 'Order not found');
+
+    const COMPLAINT_ALLOWED_STATUSES = [
+      'LAUNDRY_DELIVERED_TO_CUSTOMER',
+      'COMPLETED',
+    ];
+    if (!COMPLAINT_ALLOWED_STATUSES.includes(order.status))
+      throw new ResponseError(
+        409,
+        'Complaints can only be filed for delivered or completed orders',
+      );
+
+    const existing = await prisma.complaint.findFirst({
+      where: { orderId: data.orderId },
+    });
+    if (existing)
+      throw new ResponseError(409, 'A complaint already exists for this order');
+
+    const complaint = await prisma.complaint.create({
+      data: {
+        orderId: data.orderId,
+        customerId,
+        description: data.description,
+      },
+    });
+
+    return toComplaintResponse(complaint);
+  }
+
+  static async list(
+    role: string | undefined,
+    userId: string,
+    staffOutletId: string | null | undefined,
+    query: ComplaintListQuery,
+  ) {
+    const where = buildListWhere(role, userId, staffOutletId, query);
+    const skip = (query.page - 1) * query.limit;
+
+    const [complaints, total] = await Promise.all([
+      prisma.complaint.findMany({
+        where,
+        include: COMPLAINT_RELATIONS,
+        orderBy: { [query.sortBy]: query.order },
+        skip,
+        take: query.limit,
+      }),
+      prisma.complaint.count({ where }),
+    ]);
+
+    return {
+      data: complaints.map(toComplaintListItem),
+      meta: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    };
+  }
+
+  static async getById(
+    role: string | undefined,
+    userId: string,
+    staffOutletId: string | null | undefined,
+    complaintId: string,
+  ) {
+    const complaint = await prisma.complaint.findUnique({
+      where: { id: complaintId },
+      include: COMPLAINT_RELATIONS,
+    });
+    if (!complaint) throw new ResponseError(404, 'Complaint not found');
+
+    if (!role && complaint.customerId !== userId)
+      throw new ResponseError(404, 'Complaint not found');
+
+    if (role === 'OUTLET_ADMIN' && complaint.order.outletId !== staffOutletId)
+      throw new ResponseError(404, 'Complaint not found');
+
+    return toComplaintDetail(complaint);
+  }
+
+  static async updateStatus(
+    role: string,
+    staffOutletId: string | null | undefined,
+    complaintId: string,
+    data: UpdateComplaintStatusInput,
+  ) {
+    const complaint = await prisma.complaint.findUnique({
+      where: { id: complaintId },
+      include: { order: true },
+    });
+    if (!complaint) throw new ResponseError(404, 'Complaint not found');
+
+    if (role === 'OUTLET_ADMIN' && complaint.order.outletId !== staffOutletId)
+      throw new ResponseError(404, 'Complaint not found');
+
+    const VALID_TRANSITIONS: Partial<Record<ComplaintStatus, ComplaintStatus>> =
+      {
+        OPEN: 'IN_REVIEW',
+        IN_REVIEW: 'RESOLVED',
+      };
+
+    if (VALID_TRANSITIONS[complaint.status] !== data.status)
+      throw new ResponseError(409, 'Invalid status transition');
+
+    const updated = await prisma.complaint.update({
+      where: { id: complaintId },
+      data: { status: data.status },
+    });
+
+    return toComplaintStatusUpdate(updated);
+  }
+}

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -101,6 +101,36 @@ export const requireCustomerAuth = async (
   }
 };
 
+// Factory: allows customers through unconditionally; allows staff only if their role is in `roles`.
+// Use on routes accessible to both customers and specific staff roles (e.g. complaints list).
+export const requireAuthOrStaffRole = (...roles: StaffRole[]) => {
+  return async (req: UserRequest, res: Response, next: NextFunction) => {
+    try {
+      const result = await getSessionUser(req);
+      if (!result) {
+        res.status(401).json({ message: 'Unauthorized' });
+        return;
+      }
+
+      const staff = await prisma.staff.findUnique({ where: { userId: result.user.id } });
+
+      if (staff) {
+        if (!staff.isActive || !roles.includes(staff.role)) {
+          res.status(403).json({ message: 'Forbidden' });
+          return;
+        }
+        req.staff = staff;
+      }
+
+      req.user = result.user;
+      req.session = result.session;
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
 // Factory: returns a middleware that restricts access to staff with one of the given roles.
 // Usage: requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN')
 export const requireStaffRole = (...roles: StaffRole[]) => {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import {
   requireAuth,
+  requireAuthOrStaffRole,
   requireCustomerAuth,
   requireStaffRole,
 } from '@/middleware/auth-middleware';
@@ -19,6 +20,7 @@ import { PickupRequestController } from '@/features/pickup-requests/pickup-reque
 import { PaymentController } from '@/features/payments/payment-controller';
 import { LaundryItemController } from '@/features/laundry-items/laundry-item-controller';
 import { ShiftController } from '@/features/shifts/shift-controller';
+import { ComplaintController } from '@/features/complaints/complaint-controller';
 
 export const apiRouter = express.Router();
 
@@ -83,3 +85,7 @@ apiRouter.post('/worker/orders/:id/process', requireStaffRole('WORKER'), require
 apiRouter.post('/worker/orders/:id/bypass-request', requireStaffRole('WORKER'), requireActiveWorkerShift, BypassRequestController.createWorker);
 apiRouter.get('/worker/notifications/stream', requireStaffRole('WORKER'), WorkerNotificationController.stream);
 
+apiRouter.post('/complaints', requireCustomerAuth, ComplaintController.create);
+apiRouter.get('/complaints', requireAuthOrStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ComplaintController.list);
+apiRouter.get('/complaints/:id', requireAuthOrStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ComplaintController.getById);
+apiRouter.patch('/complaints/:id/status', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ComplaintController.updateStatus);

--- a/src/validations/complaint-validation.ts
+++ b/src/validations/complaint-validation.ts
@@ -1,0 +1,29 @@
+import { z, ZodType } from 'zod';
+import type {
+  CreateComplaintInput,
+  ComplaintListQuery,
+  UpdateComplaintStatusInput,
+} from '@/features/complaints/complaint-model';
+
+export class ComplaintValidation {
+  static readonly CREATE: ZodType<CreateComplaintInput> = z.object({
+    orderId: z.string().uuid(),
+    description: z.string().min(1),
+  });
+
+  static readonly LIST: ZodType<ComplaintListQuery> = z.object({
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().default(10),
+    status: z.enum(['OPEN', 'IN_REVIEW', 'RESOLVED']).optional(),
+    outletId: z.string().uuid().optional(),
+    orderId: z.string().uuid().optional(),
+    sortBy: z.enum(['createdAt', 'status']).default('createdAt'),
+    order: z.enum(['asc', 'desc']).default('desc'),
+  });
+
+  static readonly UPDATE_STATUS: ZodType<UpdateComplaintStatusInput> = z.object({
+    status: z.enum(['IN_REVIEW', 'RESOLVED']),
+  });
+
+  static readonly ID_PARAM: ZodType<string> = z.string().uuid();
+}


### PR DESCRIPTION
## What changed
- Customers can file complaints on delivered or completed orders (one complaint per order)
- SUPER_ADMIN and OUTLET_ADMIN can list, view, and advance complaint status through the OPEN → IN_REVIEW → RESOLVED lifecycle
- Added `requireAuthOrStaffRole` middleware factory in `auth-middleware.ts` — allows customers through unconditionally while restricting staff to the given roles; used by the complaints list and detail endpoints which must serve both audiences
- Expanded complaint contract (`docs/complaints.md`) to allow filing when `Order.status` is `LAUNDRY_DELIVERED_TO_CUSTOMER` (previously only `COMPLETED`)
- Added `orderId` query filter to `GET /complaints` (customer-only, scoped server-side)
- Fixed nodemon dev script to register tsconfig path aliases; added `dev:watch` npm script
- Added `updatedAt` field to `Complaint` schema (required by the `updateStatus` response)

## Why
Customers need a channel to report issues after their order is delivered or completed. Admins need to track and resolve these through a defined status flow.

The `requireAuthOrStaffRole` middleware change is minimal and additive — it does not alter existing `requireAuth`, `requireCustomerAuth`, or `requireStaffRole` behaviour. It was necessary because the complaint list/detail routes must serve both customers (scoped to their own complaints) and admins (scoped to their outlet or all), and no existing middleware covered this combination.

## How to test
1. `npm test` — must pass (80% coverage threshold)
2. `npm run build` — must produce zero TypeScript errors
3. POST /api/v1/complaints — file a complaint as a customer on a delivered order → 201
4. POST /api/v1/complaints — repeat same order → 409 duplicate
5. POST /api/v1/complaints — order not yet delivered → 409 wrong status
6. GET /api/v1/complaints — customer sees only their own; OUTLET_ADMIN sees only their outlet's
7. GET /api/v1/complaints/:id — 404 when complaint belongs to a different customer/outlet
8. PATCH /api/v1/complaints/:id/status — OPEN→IN_REVIEW→RESOLVED in sequence; skip a step → 409