### PR TITLE
feat: add phone field to address and surface in pickup and delivery responses

### DIFF
--- a/docs/deliveries.md
+++ b/docs/deliveries.md
@@ -43,7 +43,8 @@ List available delivery requests for the driver's outlet. Only `PENDING` deliver
         "street": "Jl. Sudirman No. 1",
         "city": "Jakarta",
         "latitude": -6.2088,
-        "longitude": 106.8456
+        "longitude": 106.8456,
+        "phone": "081234567890"
       },
       "status": "PENDING",
       "createdAt": "2026-03-08T08:00:00.000Z"
@@ -203,7 +204,8 @@ List the driver's own completed delivery history, paginated and filterable by da
       "deliveryAddress": {
         "label": "Home",
         "street": "Jl. Sudirman No. 1",
-        "city": "Jakarta"
+        "city": "Jakarta",
+        "phone": "081234567890"
       },
       "status": "DELIVERED",
       "deliveredAt": "2026-03-09T14:00:00.000Z"

--- a/docs/pickup-requests.md
+++ b/docs/pickup-requests.md
@@ -145,7 +145,8 @@ List available pickup requests for the driver's outlet. Only shows `PENDING` req
         "street": "Jl. Sudirman No. 1",
         "city": "Jakarta",
         "latitude": -6.2088,
-        "longitude": 106.8456
+        "longitude": 106.8456,
+        "phone": "081234567890"
       },
       "scheduledAt": "2026-03-10T09:00:00.000Z",
       "status": "PENDING",
@@ -304,7 +305,8 @@ List the driver's own completed pickup history, paginated and filterable by date
       "pickupAddress": {
         "label": "Home",
         "street": "Jl. Sudirman No. 1",
-        "city": "Jakarta"
+        "city": "Jakarta",
+        "phone": "081234567890"
       },
       "status": "PICKED_UP",
       "completedAt": "2026-03-10T09:45:00.000Z"

--- a/docs/users.md
+++ b/docs/users.md
@@ -477,6 +477,7 @@ List all saved addresses of the authenticated customer.
       "province": "DKI Jakarta",
       "latitude": -6.2088,
       "longitude": 106.8456,
+      "phone": "081234567890",
       "isPrimary": true,
       "createdAt": "2026-03-01T08:00:00.000Z"
     },
@@ -488,6 +489,7 @@ List all saved addresses of the authenticated customer.
       "province": "DKI Jakarta",
       "latitude": -6.1944,
       "longitude": 106.8229,
+      "phone": "081298765432",
       "isPrimary": false,
       "createdAt": "2026-03-02T08:00:00.000Z"
     }
@@ -513,7 +515,7 @@ Add a new saved address.
   "province": "DKI Jakarta",
   "latitude": -6.2088,
   "longitude": 106.8456,
-  "isPrimary": true
+  "phone": "081234567890"
 }
 ```
 
@@ -531,6 +533,7 @@ Add a new saved address.
     "province": "DKI Jakarta",
     "latitude": -6.2088,
     "longitude": 106.8456,
+    "phone": "081234567890",
     "isPrimary": true,
     "createdAt": "2026-03-06T10:00:00.000Z"
   }
@@ -565,7 +568,8 @@ Update a saved address.
   "city": "Jakarta",
   "province": "DKI Jakarta",
   "latitude": -6.209,
-  "longitude": 106.846
+  "longitude": 106.846,
+  "phone": "081298765432"
 }
 ```
 
@@ -583,6 +587,7 @@ Update a saved address.
     "province": "DKI Jakarta",
     "latitude": -6.209,
     "longitude": 106.846,
+    "phone": "081298765432",
     "isPrimary": true
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model Address {
   province       String
   latitude       Float
   longitude      Float
+  phone          String
   isPrimary      Boolean         @default(false) @map("is_primary")
   createdAt      DateTime        @default(now()) @map("created_at")
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/features/addresses/address-model.ts
+++ b/src/features/addresses/address-model.ts
@@ -7,6 +7,7 @@ export type CreateAddressInput = {
   province: string;
   latitude: number;
   longitude: number;
+  phone: string;
 };
 
 export type UpdateAddressInput = {
@@ -16,6 +17,7 @@ export type UpdateAddressInput = {
   province?: string;
   latitude?: number;
   longitude?: number;
+  phone?: string;
 };
 
 export type AddressResponse = {
@@ -27,6 +29,7 @@ export type AddressResponse = {
   province: string;
   latitude: number;
   longitude: number;
+  phone: string;
   isPrimary: boolean;
   createdAt: Date;
 };
@@ -41,6 +44,7 @@ export function toAddressResponse(address: Address): AddressResponse {
     province: address.province,
     latitude: address.latitude,
     longitude: address.longitude,
+    phone: address.phone,
     isPrimary: address.isPrimary,
     createdAt: address.createdAt,
   };

--- a/src/features/deliveries/delivery-model.ts
+++ b/src/features/deliveries/delivery-model.ts
@@ -21,6 +21,7 @@ export type DeliveryAddress = {
   province: string;
   latitude: number;
   longitude: number;
+  phone: string;
 };
 
 export type DeliveryHistoryAddress = {
@@ -28,6 +29,7 @@ export type DeliveryHistoryAddress = {
   street: string;
   city: string;
   province: string;
+  phone: string;
 };
 
 export type DeliveryListItem = {
@@ -98,6 +100,7 @@ export function toDeliveryListItem(delivery: DeliveryWithOrderChain): DeliveryLi
       province: address.province,
       latitude: address.latitude,
       longitude: address.longitude,
+      phone: address.phone,
     },
     status: delivery.status,
     createdAt: delivery.createdAt,
@@ -143,6 +146,7 @@ export function toDeliveryHistoryItem(delivery: DeliveryWithOrderChain): Deliver
       street: address.street,
       city: address.city,
       province: address.province,
+      phone: address.phone,
     },
     status: delivery.status,
     deliveredAt: delivery.deliveredAt,

--- a/src/features/pickup-requests/pickup-request-model.ts
+++ b/src/features/pickup-requests/pickup-request-model.ts
@@ -82,6 +82,7 @@ export type AddressInfo = {
   province: string;
   latitude: number;
   longitude: number;
+  phone: string;
 };
 
 export type CustomerInfo = {
@@ -125,6 +126,7 @@ export function toPickupRequestListItem(
       province: pickupRequest.address.province,
       latitude: pickupRequest.address.latitude,
       longitude: pickupRequest.address.longitude,
+      phone: pickupRequest.address.phone,
     },
     customer: {
       id: pickupRequest.customerUser.id,
@@ -163,6 +165,7 @@ export type PickupAddressInfo = {
   label: string;
   street: string;
   city: string;
+  phone: string;
 };
 
 export type PickupHistoryItem = {
@@ -195,6 +198,7 @@ export function toPickupHistoryItem(
       label: pickupRequest.address.label,
       street: pickupRequest.address.street,
       city: pickupRequest.address.city,
+      phone: pickupRequest.address.phone,
     },
     status: pickupRequest.status,
     completedAt: pickupRequest.updatedAt,

--- a/src/validations/address-validation.ts
+++ b/src/validations/address-validation.ts
@@ -13,6 +13,7 @@ export class AddressValidation {
     city: z.string().min(1).max(100),
     province: z.string().min(1).max(100),
     ...coordsSchema,
+    phone: z.string().min(8).max(20),
   });
 
   static readonly UPDATE: ZodType<UpdateAddressInput> = z
@@ -23,6 +24,7 @@ export class AddressValidation {
       province: z.string().min(1).max(100).optional(),
       latitude: coordsSchema.latitude.optional(),
       longitude: coordsSchema.longitude.optional(),
+      phone: z.string().min(8).max(20).optional(),
     })
     .refine((d) => Object.values(d).some((v) => v !== undefined), {
       message: 'At least one field must be provided',

--- a/tests/factories/delivery.factory.ts
+++ b/tests/factories/delivery.factory.ts
@@ -48,6 +48,7 @@ export const makeDeliveryAddress = (overrides: object = {}) => ({
   province: 'DKI Jakarta',
   latitude: -6.2088,
   longitude: 106.8456,
+  phone: '081234567890',
   isPrimary: true,
   createdAt: new Date(),
   ...overrides,

--- a/tests/factories/pickup-request.factory.ts
+++ b/tests/factories/pickup-request.factory.ts
@@ -7,6 +7,7 @@ export const makeAddress = (overrides: Record<string, unknown> = {}) => ({
   province: 'DKI Jakarta',
   latitude: -6.2,
   longitude: 106.8,
+  phone: '081234567890',
   isPrimary: true,
   createdAt: new Date(),
   ...overrides,

--- a/tests/integration/address-routes.test.ts
+++ b/tests/integration/address-routes.test.ts
@@ -61,6 +61,7 @@ const makeAddress = (overrides: object = {}) => ({
   province: 'DKI Jakarta',
   latitude: -6.2,
   longitude: 106.8,
+  phone: '081234567890',
   isPrimary: true,
   createdAt: new Date(),
   ...overrides,
@@ -93,6 +94,7 @@ describe('POST /api/v1/users/addresses', () => {
     province: 'Jawa Barat',
     latitude: -6.9,
     longitude: 107.6,
+    phone: '081298765432',
   };
 
   it('returns 401 when not authenticated', async () => {
@@ -123,6 +125,15 @@ describe('POST /api/v1/users/addresses', () => {
     const res = await request(app)
       .post('/api/v1/users/addresses')
       .send({ ...validBody, latitude: 200 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when phone is missing', async () => {
+    authenticatedAs();
+    const { phone: _p, ...bodyWithoutPhone } = validBody;
+    const res = await request(app)
+      .post('/api/v1/users/addresses')
+      .send(bodyWithoutPhone);
     expect(res.status).toBe(400);
   });
 });
@@ -218,7 +229,7 @@ describe('Address routes: staff access denied', () => {
     staffMock.findUnique.mockResolvedValue(staffRecord as never);
     const res = await request(app).post('/api/v1/users/addresses').send({
       label: 'Office', street: '2 Work Ave', city: 'Bandung', province: 'Jawa Barat',
-      latitude: -6.9, longitude: 107.6,
+      latitude: -6.9, longitude: 107.6, phone: '081298765432',
     });
     expect(res.status).toBe(403);
   });

--- a/tests/integration/pickup-request-routes.test.ts
+++ b/tests/integration/pickup-request-routes.test.ts
@@ -313,6 +313,7 @@ describe('GET /api/v1/pickup-requests', () => {
       province: address.province,
       latitude: address.latitude,
       longitude: address.longitude,
+      phone: address.phone,
     });
 
     expect(res.body.data[0].customer).toEqual({

--- a/tests/unit/address-service.test.ts
+++ b/tests/unit/address-service.test.ts
@@ -34,6 +34,7 @@ const makeAddress = (overrides: object = {}) => ({
   province: 'DKI Jakarta',
   latitude: -6.2,
   longitude: 106.8,
+  phone: '081234567890',
   isPrimary: true,
   createdAt: new Date(),
   ...overrides,
@@ -56,7 +57,7 @@ describe('AddressService.createAddress', () => {
     addr.create.mockResolvedValue(makeAddress({ isPrimary: true }));
     const result = await AddressService.createAddress('user-1', {
       label: 'Home', street: '1 St', city: 'Jakarta', province: 'DKI Jakarta',
-      latitude: -6.2, longitude: 106.8,
+      latitude: -6.2, longitude: 106.8, phone: '081234567890',
     });
     expect(result.isPrimary).toBe(true);
     expect(addr.create).toHaveBeenCalledWith(
@@ -69,7 +70,7 @@ describe('AddressService.createAddress', () => {
     addr.create.mockResolvedValue(makeAddress({ isPrimary: false }));
     const result = await AddressService.createAddress('user-1', {
       label: 'Office', street: '2 St', city: 'Bekasi', province: 'Jawa Barat',
-      latitude: -6.3, longitude: 107.0,
+      latitude: -6.3, longitude: 107.0, phone: '081298765432',
     });
     expect(result.isPrimary).toBe(false);
   });


### PR DESCRIPTION
## What changed

- Added optional `phone` field to the `Address` model (schema + migration)
- Address response mapper now includes `phone` in all address endpoints
- Pickup request and delivery response mappers surface the address phone field
- Updated API contract docs to reflect the new field in all affected response shapes

## Why

Drivers and outlet admins need a contact number for the customer when handling pickups and deliveries. The address is the natural place to store this since it's created at address-save time.

## How to test

1. Run `npm test` — all unit and integration tests should pass
2. Start the server: `npm run dev`
3. Create/update an address via `PATCH /api/v1/users/addresses/:id` with `"phone": "081234567890"`
4. Fetch pickup requests as a driver — confirm `address.phone` appears in each item
5. Fetch deliveries as a driver — confirm `address.phone` appears in each item
6. Run `npm run build` — TypeScript build should pass with no errors