### PR TITLE
fix: stabilize admin complaints list

### DIFF
--- a/src/features/complaints/complaint-service.ts
+++ b/src/features/complaints/complaint-service.ts
@@ -29,9 +29,9 @@ function buildListWhere(
   if (!role) {
     where.customerId = userId;
   } else if (role === 'OUTLET_ADMIN') {
-    where.order = { outletId: staffOutletId };
+    where.order = { is: { outletId: staffOutletId } };
   } else if (role === 'SUPER_ADMIN' && query.outletId) {
-    where.order = { outletId: query.outletId };
+    where.order = { is: { outletId: query.outletId } };
   }
 
   if (query.status) where.status = query.status;
@@ -80,6 +80,18 @@ export class ComplaintService {
     staffOutletId: string | null | undefined,
     query: ComplaintListQuery,
   ) {
+    if (role === 'OUTLET_ADMIN' && !staffOutletId) {
+      return {
+        data: [],
+        meta: {
+          page: query.page,
+          limit: query.limit,
+          total: 0,
+          totalPages: 0,
+        },
+      };
+    }
+
     const where = buildListWhere(role, userId, staffOutletId, query);
     const skip = (query.page - 1) * query.limit;
 


### PR DESCRIPTION
## What changed
- Fixed complaint list filtering to use the correct Prisma relation filter.
- Added a safe empty response when an Outlet Admin has no outlet scope.

## Why
The Complaints page was failing because the backend used an invalid nested order filter.

## How to test
1. Login as Super Admin and open `/admin/complaints`.
2. Verify the page loads without error.
3. Login as Outlet Admin and open `/admin/complaints`.
4. Verify the page loads without error and remains outlet-scoped.

## Verification
- `npm run build`
