### PR TITLE
fix: move outlet guard to service layer and extract named helpers

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,56 @@
+# Dashboard API Spec
+
+Provides summary statistics for the admin dashboard.
+
+**Auth:** Requires `requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN')`.
+
+**Response Envelope:**
+
+```json
+{ "status": "success" | "error", "message": "...", "data": { ... } | null }
+```
+
+---
+
+## GET /api/v1/admin/dashboard
+
+Retrieve dashboard summary statistics.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN`
+
+**Access scoping:**
+- `SUPER_ADMIN`: platform-wide totals across all outlets.
+- `OUTLET_ADMIN`: totals scoped to their assigned outlet.
+
+**Query Parameters:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Dashboard stats retrieved",
+  "data": {
+    "totalOrders": 142,
+    "activeOutlets": 5,
+    "registeredUsers": 380,
+    "revenueMtd": 4250000,
+    "recentOrders": [
+      {
+        "id": "ord_xyz789",
+        "customerName": "John Doe",
+        "status": "LAUNDRY_BEING_WASHED",
+        "outletName": "PrimeCare Jakarta Selatan",
+        "createdAt": "2026-04-20T08:00:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+**Notes:**
+
+- `revenueMtd` — sum of `totalPrice` for orders with `status = 'COMPLETED'` in the current calendar month.
+- `recentOrders` — last 5 orders by `createdAt` descending (most recent first).
+- `activeOutlets` — count of outlets with `isActive = true`. For `OUTLET_ADMIN`, this is always `1` (their own outlet).
+- `registeredUsers` — count of `User` records (customers only, no staff). For `OUTLET_ADMIN`, this reflects users who have placed orders at their outlet.

--- a/docs/deliveries.md
+++ b/docs/deliveries.md
@@ -37,11 +37,16 @@ List available delivery requests for the driver's outlet. Only `PENDING` deliver
     {
       "id": "del_001",
       "orderId": "ord_xyz789",
-      "customerName": "John Doe",
+      "customer": {
+        "id": "usr_abc123",
+        "name": "John Doe",
+        "phone": "081234567890"
+      },
       "deliveryAddress": {
         "label": "Home",
         "street": "Jl. Sudirman No. 1",
         "city": "Jakarta",
+        "province": "DKI Jakarta",
         "latitude": -6.2088,
         "longitude": 106.8456,
         "phone": "081234567890"
@@ -64,6 +69,61 @@ List available delivery requests for the driver's outlet. Only `PENDING` deliver
 - Scoped to the driver's assigned outlet only.
 - Deliveries with `status = 'PENDING'` are those waiting for a driver to accept.
 - A delivery only appears here after the linked order's `paymentStatus` is `PAID`.
+
+---
+
+## GET /api/v1/deliveries/:id/order
+
+> **Note for implementers:** Register this route in Express **before** `GET /deliveries/:id`; otherwise Express will match `order` as the `:id` parameter.
+
+Driver fetches the order summary for a delivery — useful for displaying item details before or during delivery.
+
+**Access:** `DRIVER`
+
+**Path Params:**
+
+| Param | Description   |
+| ----- | ------------- |
+| `id`  | Delivery UUID |
+
+**Request Body:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Order summary retrieved",
+  "data": {
+    "items": [
+      { "name": "T-Shirt", "quantity": 5, "unitPrice": 5000 },
+      { "name": "Trousers", "quantity": 2, "unitPrice": 8000 }
+    ],
+    "subTotal": 41000,
+    "totalPrice": 43000,
+    "deliveryFee": 2000,
+    "paymentStatus": "PAID"
+  }
+}
+```
+
+**Response (Error — 404):**
+
+```json
+{
+  "status": "error",
+  "message": "Delivery not found"
+}
+```
+
+**Response (Error — 403):**
+
+```json
+{
+  "status": "error",
+  "message": "You are not the assigned driver for this delivery"
+}
+```
 
 ---
 
@@ -200,11 +260,16 @@ List the driver's own completed delivery history, paginated and filterable by da
     {
       "id": "del_001",
       "orderId": "ord_xyz789",
-      "customerName": "John Doe",
+      "customer": {
+        "id": "usr_abc123",
+        "name": "John Doe",
+        "phone": "081234567890"
+      },
       "deliveryAddress": {
         "label": "Home",
         "street": "Jl. Sudirman No. 1",
         "city": "Jakarta",
+        "province": "DKI Jakarta",
         "phone": "081234567890"
       },
       "status": "DELIVERED",

--- a/docs/driver.md
+++ b/docs/driver.md
@@ -1,0 +1,82 @@
+# Driver API Spec
+
+Driver-specific utility endpoints.
+
+**Auth:** All endpoints require `requireStaffRole('DRIVER')`.
+
+**Response Envelope:**
+
+```json
+{ "status": "success" | "error", "message": "...", "data": { ... } | null }
+```
+
+---
+
+## GET /api/v1/drivers/me/active-task
+
+Returns the driver's currently active task (an accepted pickup or an accepted/in-progress delivery), or `null` if the driver has no active task.
+
+**Access:** `DRIVER`
+
+**Query Parameters:** None
+
+**Response (Success — 200, active pickup task):**
+
+```json
+{
+  "status": "success",
+  "message": "Active task retrieved",
+  "data": {
+    "type": "pickup",
+    "id": "pkup_abc123",
+    "customerName": "John Doe",
+    "customerPhone": "081234567890",
+    "address": {
+      "label": "Home",
+      "street": "Jl. Sudirman No. 1",
+      "city": "Jakarta"
+    }
+  }
+}
+```
+
+**Response (Success — 200, active delivery task):**
+
+```json
+{
+  "status": "success",
+  "message": "Active task retrieved",
+  "data": {
+    "type": "delivery",
+    "id": "del_001",
+    "customerName": "John Doe",
+    "customerPhone": "081234567890",
+    "address": {
+      "label": "Home",
+      "street": "Jl. Sudirman No. 1",
+      "city": "Jakarta",
+      "province": "DKI Jakarta",
+      "phone": "081234567890"
+    }
+  }
+}
+```
+
+**Response (Success — 200, no active task):**
+
+```json
+{
+  "status": "success",
+  "message": "No active task",
+  "data": null
+}
+```
+
+**Notes:**
+
+- A driver has an active task when:
+  - `PickupRequest` where `driverId = driver.id` AND `status = 'DRIVER_ASSIGNED'`
+  - `Delivery` where `driverId = driver.id` AND `status IN ['DRIVER_ASSIGNED', 'OUT_FOR_DELIVERY']`
+- Pickup address shape does not include `province` or `phone`. Delivery address includes both.
+- `customerPhone` falls back to the customer's `User.phone` if the address has no phone.
+- Use this endpoint on driver app startup to resume an interrupted session.

--- a/docs/laundry-items.md
+++ b/docs/laundry-items.md
@@ -14,6 +14,29 @@ Provides the master list of laundry item types. Used by the frontend to populate
 
 ---
 
+## GET /api/v1/laundry-items
+
+List all active laundry item types. No pagination, the list is small and fixed (28 items).
+
+**Access:** Any authenticated session (`requireAuth`) — all roles including `WORKER`, `DRIVER`, `CUSTOMER`
+
+**Query Parameters:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Laundry items retrieved",
+  "data": [
+    { "id": "uuid-tshirt", "name": "T-Shirt", "slug": "t-shirt" },
+    { "id": "uuid-trousers", "name": "Trousers", "slug": "trousers" }
+  ]
+}
+```
+
+---
+
 ## GET /api/v1/admin/laundry-items
 
 List all active laundry item types. No pagination, the list is small and fixed (28 items).
@@ -42,7 +65,7 @@ List all active laundry item types. No pagination, the list is small and fixed (
 - Returns only items with `isActive: true`.
 - Items are ordered alphabetically by name.
 - Cache this list on the frontend, it changes very rarely.
-- Workers do not need to call this endpoint directly — item data is embedded in the `previousStationItems` field returned by `POST /api/v1/orders/:id/stations/:station/start`.
+- Workers can also access the item list via `GET /api/v1/laundry-items` (no admin role required). Item data for the current station is embedded in the `referenceItems` field returned by `GET /api/v1/worker/orders/:id`.
 
 ---
 
@@ -61,7 +84,7 @@ When building item payloads for order creation or station processing, use `laund
 }
 ```
 
-**Completing a station (`PATCH /api/v1/orders/:id/stations/:station/complete`):**
+**Processing a station (`POST /api/v1/worker/orders/:id/process`):**
 
 ```json
 {

--- a/docs/orders.md
+++ b/docs/orders.md
@@ -29,6 +29,9 @@ Outlet Admin creates a formal order after laundry physically arrives at the outl
     { "laundryItemId": "uuid-tshirt", "quantity": 5 },
     { "laundryItemId": "uuid-trousers", "quantity": 2 },
     { "laundryItemId": "uuid-jacket", "quantity": 1 }
+  ],
+  "manualItems": [
+    { "name": "Custom Bag", "quantity": 1, "unitPrice": 15000 }
   ]
 }
 ```
@@ -100,6 +103,7 @@ Outlet Admin creates a formal order after laundry physically arrives at the outl
 - `pricePerKg` is locked at order creation time and stored on the order record.
 - The pickup request must have status `PICKED_UP` and belong to the admin's outlet.
 - The customer may pay from the moment this order is created.
+- Optional `manualItems` allows the admin to add non-catalogued items. These do not reference a `laundryItemId` and are priced manually via `unitPrice`.
 
 ---
 
@@ -273,3 +277,429 @@ Customer manually confirms receipt of their delivered laundry. Sets order status
 - Only valid when `order.status === 'LAUNDRY_DELIVERED_TO_CUSTOMER'`.
 - If the customer does not confirm within **2×24 hours**, a background job auto sets `status = 'COMPLETED'` and `confirmedAt = now`.
 - A customer cannot confirm an order that already has `status = 'COMPLETED'`.
+
+---
+
+## GET /api/v1/admin/orders
+
+List orders with server-side pagination, filtering, and sorting. Scoped to the admin's outlet for `OUTLET_ADMIN`; all outlets for `SUPER_ADMIN`.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN`
+
+**Query Parameters:**
+
+| Param              | Type    | Default     | Description                                          |
+| ------------------ | ------- | ----------- | ---------------------------------------------------- |
+| `page`             | number  | `1`         | Page number                                          |
+| `limit`            | number  | `10`        | Items per page                                       |
+| `status`           | string  | —           | Filter by order status enum value                    |
+| `excludeCompleted` | boolean | —           | If `true`, exclude orders with status `COMPLETED`    |
+| `fromDate`         | string  | —           | ISO 8601 date; filter `createdAt >= fromDate`        |
+| `toDate`           | string  | —           | ISO 8601 date; filter `createdAt <= toDate`          |
+| `search`           | string  | —           | Search by order ID or customer name                  |
+| `sortBy`           | string  | `createdAt` | Sort field (`createdAt`, `totalPrice`)               |
+| `order`            | string  | `desc`      | `asc` or `desc`                                      |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Orders retrieved",
+  "data": [
+    {
+      "id": "ord_xyz789",
+      "outletName": "PrimeCare Jakarta Selatan",
+      "customerName": "John Doe",
+      "totalPrice": 37000,
+      "deliveryFee": 2000,
+      "paymentStatus": "UNPAID",
+      "status": "LAUNDRY_BEING_WASHED",
+      "createdAt": "2026-03-06T12:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 1,
+    "totalPages": 1
+  }
+}
+```
+
+---
+
+## GET /api/v1/admin/orders/:id
+
+Get full order detail including items, station history, payment, and delivery info.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN` (own outlet only)
+
+**Path Params:**
+
+| Param | Description |
+| ----- | ----------- |
+| `id`  | Order UUID  |
+
+**Response (Success — 200):** Same shape as `GET /api/v1/orders/:id`.
+
+**Response (Error — 404):**
+
+```json
+{
+  "status": "error",
+  "message": "Order not found"
+}
+```
+
+---
+
+## GET /api/v1/admin/pickup-requests
+
+Admin view of all pickup requests. Used to select a pickup when creating a new order. Scoped to the admin's outlet for `OUTLET_ADMIN`; all outlets for `SUPER_ADMIN`.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN`
+
+**Query Parameters:**
+
+| Param   | Type   | Default | Description    |
+| ------- | ------ | ------- | -------------- |
+| `page`  | number | `1`     | Page number    |
+| `limit` | number | `10`    | Items per page |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Pickup requests retrieved",
+  "data": [
+    {
+      "id": "pkup_abc123",
+      "customerName": "John Doe",
+      "address": {
+        "label": "Home",
+        "street": "Jl. Sudirman No. 1",
+        "city": "Jakarta",
+        "latitude": -6.2088,
+        "longitude": 106.8456,
+        "phone": "081234567890"
+      },
+      "scheduledAt": "2026-03-10T09:00:00.000Z",
+      "status": "PICKED_UP",
+      "outletName": "PrimeCare Jakarta Selatan",
+      "createdAt": "2026-03-06T10:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 3,
+    "totalPages": 1
+  }
+}
+```
+
+---
+
+## GET /api/v1/worker/orders
+
+List station records assigned to the authenticated worker's station and outlet.
+
+**Access:** `WORKER`
+
+**Query Parameters:**
+
+| Param    | Type   | Default | Description                                                            |
+| -------- | ------ | ------- | ---------------------------------------------------------------------- |
+| `page`   | number | `1`     | Page number                                                            |
+| `limit`  | number | `10`    | Items per page                                                         |
+| `status` | string | —       | Filter by station status: `IN_PROGRESS`, `BYPASS_REQUESTED`, `COMPLETED` |
+| `date`   | string | —       | Filter by date (`YYYY-MM-DD`)                                          |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Worker orders retrieved",
+  "data": [
+    {
+      "id": "sr_001",
+      "orderId": "ord_xyz789",
+      "station": "WASHING",
+      "status": "IN_PROGRESS",
+      "totalItems": 8,
+      "customerName": "John Doe",
+      "outletName": "PrimeCare Jakarta Selatan",
+      "updatedAt": "2026-03-07T08:30:00.000Z",
+      "createdAt": "2026-03-07T08:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 3,
+    "totalPages": 1
+  }
+}
+```
+
+**Notes:**
+
+- Station and outlet are derived from `Staff.workerType` and `Staff.outletId` — no query parameter needed.
+
+---
+
+## GET /api/v1/worker/orders/:id
+
+Get detailed station record for a specific order, including reference quantities (from the previous station) and items already submitted by this worker.
+
+**Access:** `WORKER`
+
+**Path Params:**
+
+| Param | Description         |
+| ----- | ------------------- |
+| `id`  | StationRecord UUID  |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Worker order retrieved",
+  "data": {
+    "orderId": "ord_xyz789",
+    "stationRecordId": "sr_001",
+    "station": "WASHING",
+    "previousStation": null,
+    "stationStatus": "IN_PROGRESS",
+    "orderStatus": "LAUNDRY_BEING_WASHED",
+    "paymentStatus": "UNPAID",
+    "totalItems": 8,
+    "customerName": "John Doe",
+    "outletName": "PrimeCare Jakarta Selatan",
+    "createdAt": "2026-03-07T08:00:00.000Z",
+    "updatedAt": "2026-03-07T08:30:00.000Z",
+    "referenceItems": [
+      { "laundryItemId": "uuid-tshirt", "itemName": "T-Shirt", "quantity": 5 },
+      { "laundryItemId": "uuid-trousers", "itemName": "Trousers", "quantity": 2 }
+    ],
+    "stationItems": []
+  }
+}
+```
+
+**Notes:**
+
+- `referenceItems` = quantities from the previous station (or `OrderItems` for `WASHING`). Read-only reference for the worker.
+- `stationItems` = items the worker has already submitted for this station. Empty if not yet processed.
+- `previousStation` is `null` for `WASHING`.
+
+---
+
+## POST /api/v1/worker/orders/:id/process
+
+Worker submits item quantities to complete their station.
+
+- **If quantities match reference:** station is marked `COMPLETED`; order advances to the next status.
+- **If quantities mismatch:** returns `409` and the worker must submit a bypass request instead.
+
+**Access:** `WORKER` (must be on an active shift)
+
+**Path Params:**
+
+| Param | Description        |
+| ----- | ------------------ |
+| `id`  | StationRecord UUID |
+
+**Request Body:**
+
+```json
+{
+  "items": [
+    { "laundryItemId": "uuid-tshirt", "quantity": 5 },
+    { "laundryItemId": "uuid-trousers", "quantity": 2 },
+    { "laundryItemId": "uuid-jacket", "quantity": 1 }
+  ]
+}
+```
+
+**Response (Success — 200, quantities match):**
+
+```json
+{
+  "status": "success",
+  "message": "Station completed",
+  "data": {
+    "orderId": "ord_xyz789",
+    "stationRecordId": "sr_001",
+    "station": "WASHING",
+    "stationStatus": "COMPLETED",
+    "orderStatus": "LAUNDRY_BEING_IRONED",
+    "completedAt": "2026-03-07T09:00:00.000Z"
+  }
+}
+```
+
+**Response (Success — 200, Packing station, payment unpaid):**
+
+```json
+{
+  "status": "success",
+  "message": "Packing complete. Awaiting payment.",
+  "data": {
+    "orderId": "ord_xyz789",
+    "stationRecordId": "sr_003",
+    "station": "PACKING",
+    "stationStatus": "COMPLETED",
+    "orderStatus": "WAITING_FOR_PAYMENT",
+    "completedAt": "2026-03-07T15:00:00.000Z"
+  }
+}
+```
+
+**Response (Success — 200, Packing station, payment already paid):**
+
+```json
+{
+  "status": "success",
+  "message": "Packing complete. Order ready for delivery.",
+  "data": {
+    "orderId": "ord_xyz789",
+    "stationRecordId": "sr_003",
+    "station": "PACKING",
+    "stationStatus": "COMPLETED",
+    "orderStatus": "LAUNDRY_READY_FOR_DELIVERY",
+    "completedAt": "2026-03-07T15:00:00.000Z",
+    "deliveryId": "del_001"
+  }
+}
+```
+
+**Response (Error — 403):**
+
+```json
+{
+  "status": "error",
+  "message": "Worker is not on an active shift"
+}
+```
+
+**Response (Error — 409, quantities mismatch):**
+
+```json
+{
+  "status": "error",
+  "message": "Quantity mismatch. Submit a bypass request to proceed."
+}
+```
+
+**Notes — Station Progression:**
+
+| Completed Station   | Next Order Status              |
+| ------------------- | ------------------------------ |
+| `WASHING`           | `LAUNDRY_BEING_IRONED`         |
+| `IRONING`           | `LAUNDRY_BEING_PACKED`         |
+| `PACKING` (unpaid)  | `WAITING_FOR_PAYMENT`          |
+| `PACKING` (paid)    | `LAUNDRY_READY_FOR_DELIVERY` + create `Delivery` |
+
+---
+
+## POST /api/v1/worker/orders/:id/bypass-request
+
+Worker submits a bypass request when quantities do not match the reference. Sets `StationRecord.status = 'BYPASS_REQUESTED'` and creates a `BypassRequest` record.
+
+**Access:** `WORKER` (must be on an active shift)
+
+**Path Params:**
+
+| Param | Description        |
+| ----- | ------------------ |
+| `id`  | StationRecord UUID |
+
+**Request Body:**
+
+```json
+{
+  "items": [
+    { "laundryItemId": "uuid-tshirt", "quantity": 4 },
+    { "laundryItemId": "uuid-trousers", "quantity": 2 }
+  ],
+  "notes": "One T-Shirt appears to be missing"
+}
+```
+
+**Response (Success — 201):**
+
+```json
+{
+  "status": "success",
+  "message": "Bypass request submitted. Awaiting admin approval.",
+  "data": {
+    "id": "bp_001",
+    "status": "PENDING",
+    "createdAt": "2026-03-07T11:00:00.000Z"
+  }
+}
+```
+
+**Response (Error — 409):**
+
+```json
+{
+  "status": "error",
+  "message": "A pending bypass request already exists for this station"
+}
+```
+
+**Notes:**
+
+- Only one `PENDING` bypass per station record at a time.
+- The station record is blocked until the bypass is resolved by the outlet admin (`docs/bypass-requests.md`).
+
+---
+
+## GET /api/v1/worker/history
+
+List the authenticated worker's completed station records, paginated and filterable by date and station.
+
+**Access:** `WORKER`
+
+**Query Parameters:**
+
+| Param     | Type   | Default | Description                                      |
+| --------- | ------ | ------- | ------------------------------------------------ |
+| `page`    | number | `1`     | Page number                                      |
+| `limit`   | number | `10`    | Items per page                                   |
+| `station` | string | —       | Filter by station: `WASHING`, `IRONING`, `PACKING` |
+| `date`    | string | —       | Filter by date (`YYYY-MM-DD`)                    |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Worker history retrieved",
+  "data": [
+    {
+      "id": "sr_001",
+      "orderId": "ord_xyz789",
+      "station": "WASHING",
+      "status": "COMPLETED",
+      "totalItems": 8,
+      "customerName": "John Doe",
+      "outletName": "PrimeCare Jakarta Selatan",
+      "completedAt": "2026-03-07T09:00:00.000Z",
+      "createdAt": "2026-03-07T08:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 24,
+    "totalPages": 3
+  }
+}
+```

--- a/docs/outlets.md
+++ b/docs/outlets.md
@@ -1,6 +1,6 @@
 # Outlets API Spec
 
-Manages laundry outlet branches. All endpoints are under `/api/v1/outlets`.
+Manages laundry outlet branches. All endpoints are under `/api/v1/admin/outlets`.
 
 **Auth:** All endpoints require a valid session cookie (`better-auth.session_token`).
 
@@ -12,7 +12,7 @@ Manages laundry outlet branches. All endpoints are under `/api/v1/outlets`.
 
 ---
 
-## GET /api/v1/outlets
+## GET /api/v1/admin/outlets
 
 List all outlets. Super Admin sees all; Outlet Admin sees only their own.
 
@@ -60,7 +60,7 @@ List all outlets. Super Admin sees all; Outlet Admin sees only their own.
 
 ---
 
-## POST /api/v1/outlets
+## POST /api/v1/admin/outlets
 
 Create a new outlet branch.
 
@@ -107,7 +107,7 @@ Create a new outlet branch.
 
 ---
 
-## GET /api/v1/outlets/:id
+## GET /api/v1/admin/outlets/:id
 
 Get details of a specific outlet.
 
@@ -151,7 +151,7 @@ Get details of a specific outlet.
 
 ---
 
-## PATCH /api/v1/outlets/:id
+## PATCH /api/v1/admin/outlets/:id
 
 Update outlet details.
 
@@ -195,7 +195,7 @@ Update outlet details.
 
 ---
 
-## DELETE /api/v1/outlets/:id
+## DELETE /api/v1/admin/outlets/:id
 
 Deactivate an outlet (soft-delete via `isActive: false`).
 

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -80,6 +80,54 @@ Initiate payment for an order. Creates a Midtrans transaction server-side and re
 
 ---
 
+## POST /api/v1/orders/:id/payments/verify
+
+Customer manually triggers a payment status check against Midtrans. Useful after a redirect-back if the webhook has not yet fired.
+
+**Access:** `CUSTOMER`
+
+**Path Params:**
+
+| Param | Description |
+|-------|-------------|
+| `id`  | Order UUID  |
+
+**Request Body:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Payment verified",
+  "data": null
+}
+```
+
+**Response (Error — 404):**
+
+```json
+{
+  "status": "error",
+  "message": "Order not found"
+}
+```
+
+**Response (Error — 409):**
+
+```json
+{
+  "status": "error",
+  "message": "Order has already been paid"
+}
+```
+
+**Notes:**
+- Polls Midtrans transaction status server-side and applies the same settlement/expire/cancel logic as the webhook handler.
+- Idempotent: safe to call repeatedly.
+
+---
+
 ## POST /api/v1/payments/webhook
 
 Midtrans payment status webhook. This endpoint is **public** (no auth middleware) — Midtrans calls it directly after a payment event.

--- a/docs/pickup-requests.md
+++ b/docs/pickup-requests.md
@@ -76,8 +76,6 @@ Customer creates a new laundry pickup request. The server automatically assigns 
 
 ## GET /api/v1/pickup-requests/my
 
-> ⚠️ Not yet implemented
-
 List the authenticated customer's own pickup requests.
 
 **Access:** `CUSTOMER`
@@ -227,8 +225,6 @@ Driver accepts a pickup request. Sets the order status to `LAUNDRY_EN_ROUTE_TO_O
 
 ## PATCH /api/v1/pickup-requests/:id/complete
 
-> ⚠️ Not yet implemented
-
 Driver marks the pickup as complete, laundry has been collected and is arriving at the outlet.
 
 **Access:** `DRIVER`
@@ -273,8 +269,6 @@ Driver marks the pickup as complete, laundry has been collected and is arriving 
 ---
 
 ## GET /api/v1/pickup-requests/history
-
-> ⚠️ Not yet implemented
 
 List the driver's own completed pickup history, paginated and filterable by date.
 

--- a/docs/regions.md
+++ b/docs/regions.md
@@ -1,0 +1,161 @@
+# Regions API Spec
+
+Provides province/city lookup (via RajaOngkir) and address geocoding (via OpenCage) for building address forms and resolving coordinates.
+
+**Auth:** All endpoints require a valid session cookie (`better-auth.session_token`) — any authenticated role.
+
+**Response Envelope:**
+
+```json
+{ "status": "success" | "error", "message": "...", "data": { ... } | null }
+```
+
+---
+
+## GET /api/v1/regions/provinces
+
+List all available provinces.
+
+**Access:** Any authenticated session (`requireAuth`)
+
+**Query Parameters:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Provinces retrieved",
+  "data": [
+    { "id": 11, "name": "Aceh" },
+    { "id": 12, "name": "Sumatera Utara" }
+  ]
+}
+```
+
+**Notes:**
+
+- Data sourced from RajaOngkir. Province IDs are integers and match the RajaOngkir API.
+- Use `id` as `provinceId` for the `GET /regions/cities/:provinceId` endpoint.
+
+---
+
+## GET /api/v1/regions/cities/:provinceId
+
+List all cities for a given province.
+
+**Access:** Any authenticated session (`requireAuth`)
+
+**Path Params:**
+
+| Param        | Type    | Description             |
+| ------------ | ------- | ----------------------- |
+| `provinceId` | integer | Province ID (from provinces list) |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Cities retrieved",
+  "data": [
+    { "id": 39, "name": "Kota Jakarta Selatan", "zipCode": "12110" },
+    { "id": 40, "name": "Kota Jakarta Timur", "zipCode": "13210" }
+  ]
+}
+```
+
+**Response (Error — 422):**
+
+```json
+{
+  "status": "error",
+  "message": "Invalid province ID"
+}
+```
+
+---
+
+## GET /api/v1/regions/geocode
+
+Convert a city and province name into geographic coordinates.
+
+**Access:** Any authenticated session (`requireAuth`)
+
+**Query Parameters:**
+
+| Param      | Type   | Description          |
+| ---------- | ------ | -------------------- |
+| `city`     | string | City name (required) |
+| `province` | string | Province name (required) |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Geocode successful",
+  "data": {
+    "latitude": -6.2088,
+    "longitude": 106.8456
+  }
+}
+```
+
+**Response (Error — 422):**
+
+```json
+{
+  "status": "error",
+  "message": "Unable to geocode the provided address"
+}
+```
+
+**Notes:**
+
+- Coordinates sourced from OpenCage. Used for populating `latitude`/`longitude` when creating or updating an address.
+
+---
+
+## GET /api/v1/regions/reverse-geocode
+
+Convert latitude/longitude coordinates into a human-readable address.
+
+**Access:** Any authenticated session (`requireAuth`)
+
+**Query Parameters:**
+
+| Param | Type   | Description                       |
+| ----- | ------ | --------------------------------- |
+| `lat` | number | Latitude (-90 to 90)              |
+| `lng` | number | Longitude (-180 to 180)           |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Reverse geocode successful",
+  "data": {
+    "province": "DKI Jakarta",
+    "provinceId": 6,
+    "city": "Kota Jakarta Selatan",
+    "cityId": 39,
+    "streetAddress": "Jl. Fatmawati No. 5"
+  }
+}
+```
+
+**Response (Error — 422):**
+
+```json
+{
+  "status": "error",
+  "message": "Unable to resolve coordinates"
+}
+```
+
+**Notes:**
+
+- `streetAddress` may be `null` if OpenCage cannot resolve a street-level address from the given coordinates.
+- `provinceId` and `cityId` are matched against the RajaOngkir dataset.

--- a/docs/shifts.md
+++ b/docs/shifts.md
@@ -1,0 +1,165 @@
+# Shifts API Spec
+
+Manages worker shift scheduling. Workers must have an active shift to process orders at a station (`POST /api/v1/worker/orders/:id/process`).
+
+**Auth:** All endpoints require `requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN')`.
+
+**Response Envelope:**
+
+```json
+{ "status": "success" | "error", "message": "...", "data": { ... } | null }
+```
+
+---
+
+## POST /api/v1/shifts
+
+Start a new shift for a worker.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN`
+
+**Request Body:**
+
+```json
+{
+  "staffId": "staff_wrk001",
+  "startedAt": "2026-03-07T07:00:00.000Z"
+}
+```
+
+**Response (Success — 201):**
+
+```json
+{
+  "status": "success",
+  "message": "Shift started",
+  "data": {
+    "id": "shift_001",
+    "staffId": "staff_wrk001",
+    "workerType": "WASHING",
+    "workerName": "Jane Washing",
+    "outletId": "out_001",
+    "outletName": "PrimeCare Jakarta Selatan",
+    "startedAt": "2026-03-07T07:00:00.000Z",
+    "endedAt": null,
+    "isActive": true
+  }
+}
+```
+
+**Response (Error — 404):**
+
+```json
+{
+  "status": "error",
+  "message": "Staff not found"
+}
+```
+
+**Response (Error — 409):**
+
+```json
+{
+  "status": "error",
+  "message": "Staff already has an active shift"
+}
+```
+
+**Notes:**
+
+- Only staff with role `WORKER` can be assigned a shift.
+- `OUTLET_ADMIN` can only start shifts for workers at their own outlet.
+
+---
+
+## GET /api/v1/shifts
+
+List shifts with pagination and optional filtering.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN` (scoped to own outlet)
+
+**Query Parameters:**
+
+| Param      | Type    | Default | Description                          |
+| ---------- | ------- | ------- | ------------------------------------ |
+| `page`     | number  | `1`     | Page number                          |
+| `limit`    | number  | `10`    | Items per page                       |
+| `staffId`  | string  | —       | Filter by Staff UUID                 |
+| `outletId` | string  | —       | Filter by Outlet UUID (SUPER_ADMIN only) |
+| `isActive` | boolean | —       | Filter by active status              |
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Shifts retrieved",
+  "data": [
+    {
+      "id": "shift_001",
+      "staffId": "staff_wrk001",
+      "workerType": "WASHING",
+      "workerName": "Jane Washing",
+      "outletId": "out_001",
+      "outletName": "PrimeCare Jakarta Selatan",
+      "startedAt": "2026-03-07T07:00:00.000Z",
+      "endedAt": null,
+      "isActive": true
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 5,
+    "totalPages": 1
+  }
+}
+```
+
+---
+
+## PATCH /api/v1/shifts/:id/end
+
+End an active shift.
+
+**Access:** `SUPER_ADMIN`, `OUTLET_ADMIN`
+
+**Path Params:**
+
+| Param | Description |
+| ----- | ----------- |
+| `id`  | Shift UUID  |
+
+**Request Body:** None
+
+**Response (Success — 200):**
+
+```json
+{
+  "status": "success",
+  "message": "Shift ended",
+  "data": {
+    "id": "shift_001",
+    "isActive": false,
+    "endedAt": "2026-03-07T15:00:00.000Z"
+  }
+}
+```
+
+**Response (Error — 404):**
+
+```json
+{
+  "status": "error",
+  "message": "Shift not found"
+}
+```
+
+**Response (Error — 409):**
+
+```json
+{
+  "status": "error",
+  "message": "Shift has already ended"
+}
+```

--- a/docs/stations.md
+++ b/docs/stations.md
@@ -15,11 +15,15 @@ All endpoints are under `/api/v1/orders/:id/stations`.
 
 > **Item References:** All item request bodies use `laundryItemId` (UUID from `GET /api/v1/laundry-items`). Responses include both `laundryItemId` and `itemName` (from the LaundryItem join) for frontend display.
 
+> ⚠️ **Deprecation Notice:** The worker-facing station endpoints below (`start`, `complete`, `bypass`, `queue`) have been superseded by the Worker Orders flow at `/api/v1/worker/orders/*`. See `docs/orders.md` for the current worker interface.
+>
+> The read-only endpoint `GET /api/v1/orders/:id/stations` remains active for all roles and is documented below.
+
 ---
 
 ## GET /api/v1/stations/queue
 
-> ⚠️ Not yet implemented
+> ⚠️ Superseded. Use `GET /api/v1/worker/orders` instead. See `docs/orders.md`.
 
 Returns the list of orders currently waiting at the authenticated worker's station, scoped to their outlet. Station and outlet are determined from `Staff.workerType` and `Staff.outletId` — no query parameter needed.
 
@@ -123,6 +127,8 @@ Get all station records for an order, including item quantities entered at each 
 
 ## POST /api/v1/orders/:id/stations/:station/start
 
+> ⚠️ Superseded. Use `GET /api/v1/worker/orders/:id` to fetch reference items and begin processing. See `docs/orders.md`.
+
 Worker claims a station and begins processing. Creates a `StationRecord` with `status: 'IN_PROGRESS'`.
 
 **Access:** `WORKER` (matching `workerType` for the station; must be on an active shift)
@@ -183,6 +189,8 @@ Worker claims a station and begins processing. Creates a `StationRecord` with `s
 ---
 
 ## PATCH /api/v1/orders/:id/stations/:station/complete
+
+> ⚠️ Superseded. Use `POST /api/v1/worker/orders/:id/process` instead. See `docs/orders.md`.
 
 Worker submits item quantities and attempts to complete the station.
 
@@ -287,6 +295,8 @@ if order.paymentStatus === 'PAID'    → order.status = 'LAUNDRY_READY_FOR_DELIV
 ---
 
 ## POST /api/v1/orders/:id/stations/:station/bypass
+
+> ⚠️ Superseded. Use `POST /api/v1/worker/orders/:id/bypass-request` instead. See `docs/orders.md`.
 
 Worker submits a bypass request when quantities do not match the previous station. Sets `StationRecord.status = 'BYPASS_REQUESTED'` and creates a `BypassRequest` record.
 

--- a/docs/worker-notifications.md
+++ b/docs/worker-notifications.md
@@ -1,0 +1,72 @@
+# Worker Notifications API Spec
+
+Server-Sent Events (SSE) stream for real-time order arrival notifications to workers. The server pushes events when an order arrives at the worker's station.
+
+**Auth:** Requires `requireStaffRole('WORKER')`.
+
+---
+
+## GET /api/v1/worker/notifications/stream
+
+Opens a persistent SSE connection. The server sends events scoped to the worker's outlet and station (`Staff.outletId` and `Staff.workerType`).
+
+**Access:** `WORKER`
+
+**Query Parameters:** None
+
+**Response: `text/event-stream`**
+
+The response is a long-lived stream. Each event is a JSON payload sent as `data: <json>\n\n`.
+
+---
+
+### Event: Connection Established
+
+Sent immediately upon successful connection.
+
+```
+data: {"event":"worker-notification-connected","subscriberId":"sub_abc123"}
+```
+
+---
+
+### Event: Order Arrived at Station
+
+Sent when a new order reaches the worker's station.
+
+```
+data: {
+  "event": "worker-order-arrived",
+  "orderId": "ord_xyz789",
+  "outletId": "out_001",
+  "station": "WASHING",
+  "orderStatus": "LAUNDRY_BEING_WASHED",
+  "occurredAt": "2026-04-25T08:00:00.000Z"
+}
+```
+
+**Station → orderStatus mapping:**
+
+| Station  | orderStatus              |
+| -------- | ------------------------ |
+| WASHING  | LAUNDRY_BEING_WASHED     |
+| IRONING  | LAUNDRY_BEING_IRONED     |
+| PACKING  | LAUNDRY_BEING_PACKED     |
+
+---
+
+### Event: Keep-Alive Ping
+
+Sent every 25 seconds to prevent proxy/load-balancer timeouts.
+
+```
+data: {"event":"worker-notification-ping"}
+```
+
+---
+
+**Notes:**
+
+- The `EventSource` API in browsers reconnects automatically on connection drop.
+- Subscription is scoped to the authenticated worker's `outletId` and `workerType` — workers only receive events for their station and outlet.
+- After receiving `worker-order-arrived`, the worker app should call `GET /api/v1/worker/orders` to refresh the queue.

--- a/src/application/app.ts
+++ b/src/application/app.ts
@@ -26,7 +26,7 @@ app.use(
   '/api/auth',
   rateLimit({
     windowMs: 10 * 60 * 1000,
-    max: 100,
+    max: 200,
     standardHeaders: true,
     legacyHeaders: false,
   }),
@@ -36,7 +36,7 @@ app.use(
   '/api/v1',
   rateLimit({
     windowMs: 10 * 60 * 1000,
-    max: 100,
+    max: 200,
     standardHeaders: true,
     legacyHeaders: false,
   }),

--- a/src/features/complaints/complaint-controller.ts
+++ b/src/features/complaints/complaint-controller.ts
@@ -18,18 +18,8 @@ export class ComplaintController {
   static async list(req: UserRequest, res: Response, next: NextFunction) {
     try {
       const query = Validation.validate(ComplaintValidation.LIST, req.query);
-      const result = await ComplaintService.list(
-        req.staff?.role,
-        req.user!.id,
-        req.staff?.outletId,
-        query,
-      );
-      res.status(200).json({
-        status: 'success',
-        message: 'Complaints retrieved',
-        data: result.data,
-        meta: result.meta,
-      });
+      const result = await ComplaintService.list(req.staff?.role, req.user!.id, req.staff?.outletId, query);
+      res.status(200).json({ status: 'success', message: 'Complaints retrieved', data: result.data, meta: result.meta });
     } catch (error) {
       next(error);
     }

--- a/src/features/complaints/complaint-service.ts
+++ b/src/features/complaints/complaint-service.ts
@@ -18,14 +18,10 @@ const COMPLAINT_RELATIONS = {
   order: { include: { outlet: true } },
 } as const;
 
-function buildListWhere(
-  role: string | undefined,
-  userId: string,
-  staffOutletId: string | null | undefined,
-  query: ComplaintListQuery,
-) {
-  const where: Record<string, unknown> = {};
+const VALID_TRANSITIONS: Partial<Record<ComplaintStatus, ComplaintStatus>> = { OPEN: 'IN_REVIEW', IN_REVIEW: 'RESOLVED' };
 
+function buildListWhere(role: string | undefined, userId: string, staffOutletId: string | null | undefined, query: ComplaintListQuery) {
+  const where: Record<string, unknown> = {};
   if (!role) {
     where.customerId = userId;
   } else if (role === 'OUTLET_ADMIN') {
@@ -33,140 +29,61 @@ function buildListWhere(
   } else if (role === 'SUPER_ADMIN' && query.outletId) {
     where.order = { is: { outletId: query.outletId } };
   }
-
   if (query.status) where.status = query.status;
   if (query.orderId) where.orderId = query.orderId;
-
   return where;
+}
+
+async function assertOrderComplaintEligible(orderId: string, customerId: string) {
+  const order = await prisma.order.findFirst({ where: { id: orderId, pickupRequest: { customerId } } });
+  if (!order) throw new ResponseError(404, 'Order not found');
+  const ALLOWED = ['LAUNDRY_DELIVERED_TO_CUSTOMER', 'COMPLETED'];
+  if (!ALLOWED.includes(order.status))
+    throw new ResponseError(409, 'Complaints can only be filed for delivered or completed orders');
+  const existing = await prisma.complaint.findFirst({ where: { orderId } });
+  if (existing) throw new ResponseError(409, 'A complaint already exists for this order');
+}
+
+async function fetchComplaintsPage(where: Record<string, unknown>, query: ComplaintListQuery) {
+  const skip = (query.page - 1) * query.limit;
+  const [complaints, total] = await Promise.all([
+    prisma.complaint.findMany({ where, include: COMPLAINT_RELATIONS, orderBy: { [query.sortBy]: query.order }, skip, take: query.limit }),
+    prisma.complaint.count({ where }),
+  ]);
+  return { data: complaints.map(toComplaintListItem), meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) } };
 }
 
 export class ComplaintService {
   static async create(customerId: string, data: CreateComplaintInput) {
-    const order = await prisma.order.findFirst({
-      where: { id: data.orderId, pickupRequest: { customerId } },
-    });
-    if (!order) throw new ResponseError(404, 'Order not found');
-
-    const COMPLAINT_ALLOWED_STATUSES = [
-      'LAUNDRY_DELIVERED_TO_CUSTOMER',
-      'COMPLETED',
-    ];
-    if (!COMPLAINT_ALLOWED_STATUSES.includes(order.status))
-      throw new ResponseError(
-        409,
-        'Complaints can only be filed for delivered or completed orders',
-      );
-
-    const existing = await prisma.complaint.findFirst({
-      where: { orderId: data.orderId },
-    });
-    if (existing)
-      throw new ResponseError(409, 'A complaint already exists for this order');
-
+    await assertOrderComplaintEligible(data.orderId, customerId);
     const complaint = await prisma.complaint.create({
-      data: {
-        orderId: data.orderId,
-        customerId,
-        description: data.description,
-      },
+      data: { orderId: data.orderId, customerId, description: data.description },
     });
-
     return toComplaintResponse(complaint);
   }
 
-  static async list(
-    role: string | undefined,
-    userId: string,
-    staffOutletId: string | null | undefined,
-    query: ComplaintListQuery,
-  ) {
-    if (role === 'OUTLET_ADMIN' && !staffOutletId) {
-      return {
-        data: [],
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          total: 0,
-          totalPages: 0,
-        },
-      };
-    }
-
-    const where = buildListWhere(role, userId, staffOutletId, query);
-    const skip = (query.page - 1) * query.limit;
-
-    const [complaints, total] = await Promise.all([
-      prisma.complaint.findMany({
-        where,
-        include: COMPLAINT_RELATIONS,
-        orderBy: { [query.sortBy]: query.order },
-        skip,
-        take: query.limit,
-      }),
-      prisma.complaint.count({ where }),
-    ]);
-
-    return {
-      data: complaints.map(toComplaintListItem),
-      meta: {
-        page: query.page,
-        limit: query.limit,
-        total,
-        totalPages: Math.ceil(total / query.limit),
-      },
-    };
+  static async list(role: string | undefined, userId: string, staffOutletId: string | null | undefined, query: ComplaintListQuery) {
+    if (role === 'OUTLET_ADMIN' && !staffOutletId)
+      return { data: [], meta: { page: query.page, limit: query.limit, total: 0, totalPages: 0 } };
+    return fetchComplaintsPage(buildListWhere(role, userId, staffOutletId, query), query);
   }
 
-  static async getById(
-    role: string | undefined,
-    userId: string,
-    staffOutletId: string | null | undefined,
-    complaintId: string,
-  ) {
-    const complaint = await prisma.complaint.findUnique({
-      where: { id: complaintId },
-      include: COMPLAINT_RELATIONS,
-    });
+  static async getById(role: string | undefined, userId: string, staffOutletId: string | null | undefined, complaintId: string) {
+    const complaint = await prisma.complaint.findUnique({ where: { id: complaintId }, include: COMPLAINT_RELATIONS });
     if (!complaint) throw new ResponseError(404, 'Complaint not found');
-
-    if (!role && complaint.customerId !== userId)
-      throw new ResponseError(404, 'Complaint not found');
-
-    if (role === 'OUTLET_ADMIN' && complaint.order.outletId !== staffOutletId)
-      throw new ResponseError(404, 'Complaint not found');
-
+    if (!role && complaint.customerId !== userId) throw new ResponseError(404, 'Complaint not found');
+    if (role === 'OUTLET_ADMIN' && complaint.order.outletId !== staffOutletId) throw new ResponseError(404, 'Complaint not found');
     return toComplaintDetail(complaint);
   }
 
-  static async updateStatus(
-    role: string,
-    staffOutletId: string | null | undefined,
-    complaintId: string,
-    data: UpdateComplaintStatusInput,
-  ) {
-    const complaint = await prisma.complaint.findUnique({
-      where: { id: complaintId },
-      include: { order: true },
-    });
+  static async updateStatus(role: string, staffOutletId: string | null | undefined, complaintId: string, data: UpdateComplaintStatusInput) {
+    const complaint = await prisma.complaint.findUnique({ where: { id: complaintId }, include: { order: true } });
     if (!complaint) throw new ResponseError(404, 'Complaint not found');
-
     if (role === 'OUTLET_ADMIN' && complaint.order.outletId !== staffOutletId)
       throw new ResponseError(404, 'Complaint not found');
-
-    const VALID_TRANSITIONS: Partial<Record<ComplaintStatus, ComplaintStatus>> =
-      {
-        OPEN: 'IN_REVIEW',
-        IN_REVIEW: 'RESOLVED',
-      };
-
     if (VALID_TRANSITIONS[complaint.status] !== data.status)
       throw new ResponseError(409, 'Invalid status transition');
-
-    const updated = await prisma.complaint.update({
-      where: { id: complaintId },
-      data: { status: data.status },
-    });
-
+    const updated = await prisma.complaint.update({ where: { id: complaintId }, data: { status: data.status } });
     return toComplaintStatusUpdate(updated);
   }
 }

--- a/src/features/deliveries/delivery-controller.ts
+++ b/src/features/deliveries/delivery-controller.ts
@@ -31,6 +31,12 @@ export class DeliveryController {
     });
   }
 
+  static async getOrderSummary(req: UserRequest, res: Response) {
+    const deliveryId = Validation.validate(DeliveryValidation.ID_PARAM, req.params.id);
+    const response = await DeliveryService.getOrderSummary(req.staff!.id, deliveryId);
+    res.json({ status: 'success', message: 'Order summary retrieved', data: response });
+  }
+
   static async complete(req: UserRequest, res: Response) {
     const deliveryId = Validation.validate(DeliveryValidation.ID_PARAM, req.params.id);
     const response = await DeliveryService.completeDelivery(req.staff!.id, deliveryId);

--- a/src/features/deliveries/delivery-model.ts
+++ b/src/features/deliveries/delivery-model.ts
@@ -1,4 +1,4 @@
-import type { Delivery, Order, PickupRequest, Address, User } from '@/generated/prisma/client';
+import type { Delivery, Order, OrderItem, LaundryItem, PickupRequest, Address, User } from '@/generated/prisma/client';
 import { DeliveryStatus, OrderStatus } from '@/generated/prisma/enums';
 
 export type PaginationMeta = {
@@ -73,6 +73,35 @@ export type PaginatedDeliveryHistoryResponse = {
   data: DeliveryHistoryItem[];
   meta: PaginationMeta;
 };
+
+export type DeliveryOrderItem = {
+  name: string;
+  quantity: number;
+  unitPrice: number;
+};
+
+export type DeliveryOrderSummary = {
+  items: DeliveryOrderItem[];
+  totalPrice: number;
+  deliveryFee: number;
+};
+
+type OrderItemWithLaundryItem = OrderItem & { laundryItem: LaundryItem };
+type DeliveryWithOrderSummary = Delivery & {
+  order: Order & { items: OrderItemWithLaundryItem[] };
+};
+
+export function toDeliveryOrderSummary(delivery: DeliveryWithOrderSummary): DeliveryOrderSummary {
+  return {
+    items: delivery.order.items.map((item) => ({
+      name: item.laundryItem.name,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice ?? 0,
+    })),
+    totalPrice: delivery.order.totalPrice,
+    deliveryFee: delivery.order.deliveryFee,
+  };
+}
 
 type DeliveryWithOrderChain = Delivery & {
   order: Order & {

--- a/src/features/deliveries/delivery-model.ts
+++ b/src/features/deliveries/delivery-model.ts
@@ -116,25 +116,17 @@ type DeliveryWithOrderChain = Delivery & {
   };
 };
 
+function mapCustomer(user: User): DeliveryCustomerInfo {
+  return { id: user.id, name: user.name, phone: user.phone };
+}
+
 export function toDeliveryListItem(delivery: DeliveryWithOrderChain): DeliveryListItem {
   const { address, customerUser } = delivery.order.pickupRequest;
   return {
     id: delivery.id,
     orderId: delivery.orderId,
-    customer: {
-      id: customerUser.id,
-      name: customerUser.name,
-      phone: customerUser.phone,
-    },
-    deliveryAddress: {
-      label: address.label,
-      street: address.street,
-      city: address.city,
-      province: address.province,
-      latitude: address.latitude,
-      longitude: address.longitude,
-      phone: address.phone,
-    },
+    customer: mapCustomer(customerUser),
+    deliveryAddress: { label: address.label, street: address.street, city: address.city, province: address.province, latitude: address.latitude, longitude: address.longitude, phone: address.phone },
     status: delivery.status,
     createdAt: delivery.createdAt,
   };
@@ -169,18 +161,8 @@ export function toDeliveryHistoryItem(delivery: DeliveryWithOrderChain): Deliver
   return {
     id: delivery.id,
     orderId: delivery.orderId,
-    customer: {
-      id: customerUser.id,
-      name: customerUser.name,
-      phone: customerUser.phone,
-    },
-    deliveryAddress: {
-      label: address.label,
-      street: address.street,
-      city: address.city,
-      province: address.province,
-      phone: address.phone,
-    },
+    customer: mapCustomer(customerUser),
+    deliveryAddress: { label: address.label, street: address.street, city: address.city, province: address.province, phone: address.phone },
     status: delivery.status,
     deliveredAt: delivery.deliveredAt,
   };

--- a/src/features/deliveries/delivery-model.ts
+++ b/src/features/deliveries/delivery-model.ts
@@ -1,5 +1,5 @@
 import type { Delivery, Order, OrderItem, LaundryItem, PickupRequest, Address, User } from '@/generated/prisma/client';
-import { DeliveryStatus, OrderStatus } from '@/generated/prisma/enums';
+import { DeliveryStatus, OrderPaymentStatus, OrderStatus } from '@/generated/prisma/enums';
 
 export type PaginationMeta = {
   page: number;
@@ -82,8 +82,10 @@ export type DeliveryOrderItem = {
 
 export type DeliveryOrderSummary = {
   items: DeliveryOrderItem[];
+  subTotal: number;
   totalPrice: number;
   deliveryFee: number;
+  paymentStatus: OrderPaymentStatus;
 };
 
 type OrderItemWithLaundryItem = OrderItem & { laundryItem: LaundryItem };
@@ -98,8 +100,10 @@ export function toDeliveryOrderSummary(delivery: DeliveryWithOrderSummary): Deli
       quantity: item.quantity,
       unitPrice: item.unitPrice ?? 0,
     })),
+    subTotal: delivery.order.totalPrice - delivery.order.deliveryFee,
     totalPrice: delivery.order.totalPrice,
     deliveryFee: delivery.order.deliveryFee,
+    paymentStatus: delivery.order.paymentStatus,
   };
 }
 

--- a/src/features/deliveries/delivery-service.ts
+++ b/src/features/deliveries/delivery-service.ts
@@ -39,84 +39,44 @@ async function checkDriverHasActiveTask(tx: Prisma.TransactionClient, staffId: s
   if (activePickup || activeDelivery) throw new ResponseError(409, 'Driver already has an active task');
 }
 
+async function runAcceptDeliveryTx(tx: Prisma.TransactionClient, staffId: string, deliveryId: string, outletId: string) {
+  await checkDriverHasActiveTask(tx, staffId);
+  // Atomic update: only succeeds if status is still PENDING (prevents concurrent accepts)
+  const updated = await tx.delivery
+    .update({ where: { id: deliveryId, status: DeliveryStatus.PENDING }, data: { driverId: staffId, status: DeliveryStatus.DRIVER_ASSIGNED }, include: { order: true } })
+    .catch(() => { throw new ResponseError(404, 'Delivery not found'); });
+  if (updated.order.outletId !== outletId) throw new ResponseError(403, 'Delivery belongs to a different outlet');
+  await tx.order.update({ where: { id: updated.orderId }, data: { status: OrderStatus.LAUNDRY_OUT_FOR_DELIVERY } });
+  return toDeliveryAcceptResponse(updated as typeof updated & { driverId: string }, OrderStatus.LAUNDRY_OUT_FOR_DELIVERY);
+}
+
+async function runCompleteDeliveryTx(tx: Prisma.TransactionClient, staffId: string, deliveryId: string) {
+  const delivery = await tx.delivery.findFirst({ where: { id: deliveryId, status: DeliveryStatus.DRIVER_ASSIGNED } });
+  if (!delivery) throw new ResponseError(404, 'Delivery not found or not in assigned state');
+  if (delivery.driverId !== staffId) throw new ResponseError(403, 'You are not the assigned driver for this delivery');
+  const now = new Date();
+  const updated = await tx.delivery.update({ where: { id: deliveryId }, data: { status: DeliveryStatus.DELIVERED, deliveredAt: now } });
+  await tx.order.update({ where: { id: delivery.orderId }, data: { status: OrderStatus.LAUNDRY_DELIVERED_TO_CUSTOMER } });
+  return toDeliveryCompleteResponse(updated as typeof updated & { deliveredAt: Date }, OrderStatus.LAUNDRY_DELIVERED_TO_CUSTOMER);
+}
+
 export class DeliveryService {
   static async listDeliveries(outletId: string, query: DeliveryListQuery): Promise<PaginatedDeliveryListResponse> {
     const skip = (query.page - 1) * query.limit;
-    const where = {
-      status: query.status,
-      order: { outletId, paymentStatus: 'PAID' as const },
-    };
-
+    const where = { status: query.status, order: { outletId, paymentStatus: 'PAID' as const } };
     const [deliveries, total] = await prisma.$transaction([
-      prisma.delivery.findMany({
-        where,
-        include: orderChainInclude,
-        orderBy: { createdAt: 'asc' },
-        skip,
-        take: query.limit,
-      }),
+      prisma.delivery.findMany({ where, include: orderChainInclude, orderBy: { createdAt: 'asc' }, skip, take: query.limit }),
       prisma.delivery.count({ where }),
     ]);
-
-    return {
-      data: deliveries.map(toDeliveryListItem),
-      meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) },
-    };
+    return { data: deliveries.map(toDeliveryListItem), meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) } };
   }
 
   static async acceptDelivery(staffId: string, deliveryId: string, outletId: string) {
-    return prisma.$transaction(async (tx) => {
-      await checkDriverHasActiveTask(tx, staffId);
-
-      // Atomic update: only succeeds if status is still PENDING (prevents concurrent accepts)
-      const updated = await tx.delivery
-        .update({
-          where: { id: deliveryId, status: DeliveryStatus.PENDING },
-          data: { driverId: staffId, status: DeliveryStatus.DRIVER_ASSIGNED },
-          include: { order: true },
-        })
-        .catch(() => { throw new ResponseError(404, 'Delivery not found'); });
-
-      if (updated.order.outletId !== outletId) throw new ResponseError(403, 'Delivery belongs to a different outlet');
-
-      await tx.order.update({
-        where: { id: updated.orderId },
-        data: { status: OrderStatus.LAUNDRY_OUT_FOR_DELIVERY },
-      });
-
-      return toDeliveryAcceptResponse(
-        updated as typeof updated & { driverId: string },
-        OrderStatus.LAUNDRY_OUT_FOR_DELIVERY
-      );
-    });
+    return prisma.$transaction((tx) => runAcceptDeliveryTx(tx, staffId, deliveryId, outletId));
   }
 
   static async completeDelivery(staffId: string, deliveryId: string) {
-    return prisma.$transaction(async (tx) => {
-      const delivery = await tx.delivery.findFirst({
-        where: { id: deliveryId, status: DeliveryStatus.DRIVER_ASSIGNED },
-      });
-
-      if (!delivery) throw new ResponseError(404, 'Delivery not found or not in assigned state');
-      if (delivery.driverId !== staffId) throw new ResponseError(403, 'You are not the assigned driver for this delivery');
-
-      const now = new Date();
-
-      const updated = await tx.delivery.update({
-        where: { id: deliveryId },
-        data: { status: DeliveryStatus.DELIVERED, deliveredAt: now },
-      });
-
-      await tx.order.update({
-        where: { id: delivery.orderId },
-        data: { status: OrderStatus.LAUNDRY_DELIVERED_TO_CUSTOMER },
-      });
-
-      return toDeliveryCompleteResponse(
-        updated as typeof updated & { deliveredAt: Date },
-        OrderStatus.LAUNDRY_DELIVERED_TO_CUSTOMER
-      );
-    });
+    return prisma.$transaction((tx) => runCompleteDeliveryTx(tx, staffId, deliveryId));
   }
 
   static async getOrderSummary(staffId: string, deliveryId: string) {
@@ -137,29 +97,13 @@ export class DeliveryService {
   static async listDriverHistory(staffId: string, query: DeliveryHistoryQuery): Promise<PaginatedDeliveryHistoryResponse> {
     const skip = (query.page - 1) * query.limit;
     const dateFilter = query.fromDate ?? query.toDate
-      ? {
-          deliveredAt: {
-            ...(query.fromDate && { gte: new Date(query.fromDate) }),
-            ...(query.toDate && { lte: new Date(query.toDate) }),
-          },
-        }
+      ? { deliveredAt: { ...(query.fromDate && { gte: new Date(query.fromDate) }), ...(query.toDate && { lte: new Date(query.toDate) }) } }
       : {};
     const where = { driverId: staffId, status: DeliveryStatus.DELIVERED, ...dateFilter };
-
     const [deliveries, total] = await prisma.$transaction([
-      prisma.delivery.findMany({
-        where,
-        include: orderChainInclude,
-        orderBy: { [query.sortBy]: query.order },
-        skip,
-        take: query.limit,
-      }),
+      prisma.delivery.findMany({ where, include: orderChainInclude, orderBy: { [query.sortBy]: query.order }, skip, take: query.limit }),
       prisma.delivery.count({ where }),
     ]);
-
-    return {
-      data: deliveries.map(toDeliveryHistoryItem),
-      meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) },
-    };
+    return { data: deliveries.map(toDeliveryHistoryItem), meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) } };
   }
 }

--- a/src/features/deliveries/delivery-service.ts
+++ b/src/features/deliveries/delivery-service.ts
@@ -11,6 +11,7 @@ import {
   toDeliveryAcceptResponse,
   toDeliveryCompleteResponse,
   toDeliveryHistoryItem,
+  toDeliveryOrderSummary,
   PaginatedDeliveryListResponse,
   PaginatedDeliveryHistoryResponse,
 } from './delivery-model';
@@ -116,6 +117,21 @@ export class DeliveryService {
         OrderStatus.LAUNDRY_DELIVERED_TO_CUSTOMER
       );
     });
+  }
+
+  static async getOrderSummary(staffId: string, deliveryId: string) {
+    const delivery = await prisma.delivery.findFirst({
+      where: { id: deliveryId, driverId: staffId },
+      include: {
+        order: {
+          include: {
+            items: { include: { laundryItem: true } },
+          },
+        },
+      },
+    });
+    if (!delivery) throw new ResponseError(404, 'Delivery not found');
+    return toDeliveryOrderSummary(delivery);
   }
 
   static async listDriverHistory(staffId: string, query: DeliveryHistoryQuery): Promise<PaginatedDeliveryHistoryResponse> {

--- a/src/features/driver/driver-controller.ts
+++ b/src/features/driver/driver-controller.ts
@@ -1,0 +1,10 @@
+import { Response } from 'express';
+import { DriverService } from './driver-service';
+import type { UserRequest } from '@/types/user-request';
+
+export class DriverController {
+  static async getActiveTask(req: UserRequest, res: Response) {
+    const response = await DriverService.getActiveTask(req.staff!.id);
+    res.json({ status: 'success', message: 'Active task retrieved', data: response });
+  }
+}

--- a/src/features/driver/driver-model.ts
+++ b/src/features/driver/driver-model.ts
@@ -47,12 +47,6 @@ export function toDriverActiveDeliveryTask(delivery: DeliveryWithOrderChain): Dr
     id: delivery.id,
     customerName: customerUser.name,
     customerPhone: address.phone ?? customerUser.phone,
-    address: {
-      label: address.label,
-      street: address.street,
-      city: address.city,
-      province: address.province,
-      phone: address.phone,
-    },
+    address: { label: address.label, street: address.street, city: address.city, province: address.province, phone: address.phone },
   };
 }

--- a/src/features/driver/driver-model.ts
+++ b/src/features/driver/driver-model.ts
@@ -1,0 +1,58 @@
+import type { PickupRequest, Delivery, Order, Address, User } from '@/generated/prisma/client';
+
+export type DriverActivePickupTask = {
+  type: 'pickup';
+  id: string;
+  customerName: string | null;
+  customerPhone: string | null;
+  address: { label: string; street: string; city: string };
+};
+
+export type DriverActiveDeliveryTask = {
+  type: 'delivery';
+  id: string;
+  customerName: string | null;
+  customerPhone: string | null;
+  address: { label: string; street: string; city: string; province: string; phone: string };
+};
+
+export type DriverActiveTaskResponse = DriverActivePickupTask | DriverActiveDeliveryTask | null;
+
+type PickupWithAddress = PickupRequest & { address: Address; customerUser: User };
+
+type DeliveryWithOrderChain = Delivery & {
+  order: Order & {
+    pickupRequest: PickupRequest & { address: Address; customerUser: User };
+  };
+};
+
+export function toDriverActivePickupTask(pickup: PickupWithAddress): DriverActivePickupTask {
+  return {
+    type: 'pickup',
+    id: pickup.id,
+    customerName: pickup.customerUser.name,
+    customerPhone: pickup.address.phone ?? pickup.customerUser.phone,
+    address: {
+      label: pickup.address.label,
+      street: pickup.address.street,
+      city: pickup.address.city,
+    },
+  };
+}
+
+export function toDriverActiveDeliveryTask(delivery: DeliveryWithOrderChain): DriverActiveDeliveryTask {
+  const { address, customerUser } = delivery.order.pickupRequest;
+  return {
+    type: 'delivery',
+    id: delivery.id,
+    customerName: customerUser.name,
+    customerPhone: address.phone ?? customerUser.phone,
+    address: {
+      label: address.label,
+      street: address.street,
+      city: address.city,
+      province: address.province,
+      phone: address.phone,
+    },
+  };
+}

--- a/src/features/driver/driver-service.ts
+++ b/src/features/driver/driver-service.ts
@@ -1,0 +1,36 @@
+import { prisma } from '@/application/database';
+import { PickupStatus, DeliveryStatus } from '@/generated/prisma/enums';
+import {
+  toDriverActivePickupTask,
+  toDriverActiveDeliveryTask,
+  type DriverActiveTaskResponse,
+} from './driver-model';
+
+export class DriverService {
+  static async getActiveTask(staffId: string): Promise<DriverActiveTaskResponse> {
+    const activePickup = await prisma.pickupRequest.findFirst({
+      where: { driverId: staffId, status: PickupStatus.DRIVER_ASSIGNED },
+      include: { address: true, customerUser: true },
+    });
+    if (activePickup) return toDriverActivePickupTask(activePickup);
+
+    const activeDelivery = await prisma.delivery.findFirst({
+      where: {
+        driverId: staffId,
+        status: { in: [DeliveryStatus.DRIVER_ASSIGNED, DeliveryStatus.OUT_FOR_DELIVERY] },
+      },
+      include: {
+        order: {
+          include: {
+            pickupRequest: {
+              include: { address: true, customerUser: true },
+            },
+          },
+        },
+      },
+    });
+    if (activeDelivery) return toDriverActiveDeliveryTask(activeDelivery);
+
+    return null;
+  }
+}

--- a/src/features/driver/driver-service.ts
+++ b/src/features/driver/driver-service.ts
@@ -6,31 +6,24 @@ import {
   type DriverActiveTaskResponse,
 } from './driver-model';
 
+const findActivePickup = (staffId: string) =>
+  prisma.pickupRequest.findFirst({
+    where: { driverId: staffId, status: PickupStatus.DRIVER_ASSIGNED },
+    include: { address: true, customerUser: true },
+  });
+
+const findActiveDelivery = (staffId: string) =>
+  prisma.delivery.findFirst({
+    where: { driverId: staffId, status: { in: [DeliveryStatus.DRIVER_ASSIGNED, DeliveryStatus.OUT_FOR_DELIVERY] } },
+    include: { order: { include: { pickupRequest: { include: { address: true, customerUser: true } } } } },
+  });
+
 export class DriverService {
   static async getActiveTask(staffId: string): Promise<DriverActiveTaskResponse> {
-    const activePickup = await prisma.pickupRequest.findFirst({
-      where: { driverId: staffId, status: PickupStatus.DRIVER_ASSIGNED },
-      include: { address: true, customerUser: true },
-    });
+    const activePickup = await findActivePickup(staffId);
     if (activePickup) return toDriverActivePickupTask(activePickup);
-
-    const activeDelivery = await prisma.delivery.findFirst({
-      where: {
-        driverId: staffId,
-        status: { in: [DeliveryStatus.DRIVER_ASSIGNED, DeliveryStatus.OUT_FOR_DELIVERY] },
-      },
-      include: {
-        order: {
-          include: {
-            pickupRequest: {
-              include: { address: true, customerUser: true },
-            },
-          },
-        },
-      },
-    });
+    const activeDelivery = await findActiveDelivery(staffId);
     if (activeDelivery) return toDriverActiveDeliveryTask(activeDelivery);
-
     return null;
   }
 }

--- a/src/features/payments/payment-model.ts
+++ b/src/features/payments/payment-model.ts
@@ -15,19 +15,18 @@ export interface InitiatePaymentResponse {
   redirectUrl: string;
 }
 
+const getMidtransBaseUrl = () =>
+  process.env.MIDTRANS_IS_PRODUCTION === 'true'
+    ? 'https://app.midtrans.com'
+    : 'https://app.sandbox.midtrans.com';
+
 export const toInitiatePaymentResponse = (
   payment: { id: string; orderId: string; amount: number },
   snapToken: string,
-): InitiatePaymentResponse => {
-  const base =
-    process.env.MIDTRANS_IS_PRODUCTION === 'true'
-      ? 'https://app.midtrans.com'
-      : 'https://app.sandbox.midtrans.com';
-  return {
-    paymentId:   payment.id,
-    orderId:     payment.orderId,
-    amount:      payment.amount,
-    snapToken,
-    redirectUrl: `${base}/snap/v2/vtweb/${snapToken}`,
-  };
-};
+): InitiatePaymentResponse => ({
+  paymentId: payment.id,
+  orderId: payment.orderId,
+  amount: payment.amount,
+  snapToken,
+  redirectUrl: `${getMidtransBaseUrl()}/snap/v2/vtweb/${snapToken}`,
+});

--- a/src/features/payments/payment-service.ts
+++ b/src/features/payments/payment-service.ts
@@ -4,6 +4,7 @@ import MidtransClient from 'midtrans-client';
 import { prisma } from '@/application/database';
 import { logger } from '@/application/logging';
 import { ResponseError } from '@/error/response-error';
+import type { Prisma } from '@/generated/prisma/client';
 import {
   InitiatePaymentResponse,
   MidtransWebhookPayload,
@@ -51,134 +52,70 @@ const fetchOrderForPayment = (orderId: string) =>
     },
   });
 
-const persistNewPayment = async (
-  orderId: string,
-  hasOldPayment: boolean,
-  totalPrice: number,
-) => {
+async function upsertPaymentRecord(tx: Prisma.TransactionClient, paymentId: string, orderId: string, token: string, totalPrice: number, hasOldPayment: boolean) {
+  if (hasOldPayment) await tx.payment.delete({ where: { orderId } }); // Midtrans rejects reused order_id
+  return tx.payment.create({ data: { id: paymentId, orderId, amount: totalPrice, gateway: 'midtrans', gatewayTxId: token, status: 'PENDING' } });
+}
+
+const persistNewPayment = async (orderId: string, hasOldPayment: boolean, totalPrice: number) => {
   const paymentId = uuidv4();
-  const { token } = await getSnap().createTransaction({
-    transaction_details: { order_id: paymentId, gross_amount: totalPrice },
-  });
-  const payment = await prisma.$transaction(async (tx) => {
-    if (hasOldPayment) await tx.payment.delete({ where: { orderId } }); // Midtrans rejects reused order_id
-    return tx.payment.create({
-      data: {
-        id: paymentId,
-        orderId,
-        amount: totalPrice,
-        gateway: 'midtrans',
-        gatewayTxId: token,
-        status: 'PENDING',
-      },
-    });
-  });
+  const { token } = await getSnap().createTransaction({ transaction_details: { order_id: paymentId, gross_amount: totalPrice } });
+  const payment = await prisma.$transaction((tx) => upsertPaymentRecord(tx, paymentId, orderId, token, totalPrice, hasOldPayment));
   return { payment, snapToken: token };
 };
 
 const processFailure = (paymentId: string, status: 'EXPIRED' | 'FAILED') =>
   prisma.payment.update({ where: { id: paymentId }, data: { status } });
 
-const processSettlement = (
-  paymentId: string,
-  orderId: string,
-  orderStatus: string,
-) => {
+async function runSettlementTx(tx: Prisma.TransactionClient, paymentId: string, orderId: string, isWaitingForPayment: boolean) {
+  await tx.payment.update({ where: { id: paymentId }, data: { status: 'PAID', paidAt: new Date() } });
+  await tx.order.update({ where: { id: orderId }, data: { paymentStatus: 'PAID', ...(isWaitingForPayment && { status: 'LAUNDRY_READY_FOR_DELIVERY' }) } });
+  if (isWaitingForPayment) await tx.delivery.create({ data: { orderId, status: 'PENDING' } });
+}
+
+const processSettlement = (paymentId: string, orderId: string, orderStatus: string) => {
   const isWaitingForPayment = orderStatus === 'WAITING_FOR_PAYMENT';
-  return prisma.$transaction(async (tx) => {
-    await tx.payment.update({
-      where: { id: paymentId },
-      data: { status: 'PAID', paidAt: new Date() },
-    });
-    await tx.order.update({
-      where: { id: orderId },
-      data: {
-        paymentStatus: 'PAID',
-        ...(isWaitingForPayment && { status: 'LAUNDRY_READY_FOR_DELIVERY' }),
-      },
-    });
-    if (isWaitingForPayment)
-      await tx.delivery.create({ data: { orderId, status: 'PENDING' } });
-  });
+  return prisma.$transaction((tx) => runSettlementTx(tx, paymentId, orderId, isWaitingForPayment));
 };
 
+async function dispatchWebhookStatus(payload: MidtransWebhookPayload, paymentId: string, orderId: string, orderStatus: string) {
+  const { transaction_status, fraud_status } = payload;
+  if (transaction_status === 'settlement' && fraud_status !== 'deny')
+    return void (await processSettlement(paymentId, orderId, orderStatus));
+  if (transaction_status === 'expire') await processFailure(paymentId, 'EXPIRED');
+  else if (transaction_status === 'cancel' || transaction_status === 'deny') await processFailure(paymentId, 'FAILED');
+}
+
 export class PaymentService {
-  static async initiatePayment(
-    customerId: string,
-    orderId: string,
-  ): Promise<InitiatePaymentResponse> {
+  static async initiatePayment(customerId: string, orderId: string): Promise<InitiatePaymentResponse> {
     const order = await fetchOrderForPayment(orderId);
     if (!order) throw new ResponseError(404, 'Order not found');
-    if (order.pickupRequest.customerId !== customerId)
-      throw new ResponseError(
-        403,
-        'You are not authorized to pay for this order',
-      );
-    if (order.paymentStatus === 'PAID')
-      throw new ResponseError(409, 'Order has already been paid');
-
+    if (order.pickupRequest.customerId !== customerId) throw new ResponseError(403, 'You are not authorized to pay for this order');
+    if (order.paymentStatus === 'PAID') throw new ResponseError(409, 'Order has already been paid');
     if (order.payment?.status === 'PENDING' && order.payment.gatewayTxId)
-      return toInitiatePaymentResponse(
-        order.payment,
-        order.payment.gatewayTxId,
-      );
-
-    const { payment, snapToken } = await persistNewPayment(
-      orderId,
-      !!order.payment,
-      order.totalPrice,
-    );
+      return toInitiatePaymentResponse(order.payment, order.payment.gatewayTxId);
+    const { payment, snapToken } = await persistNewPayment(orderId, !!order.payment, order.totalPrice);
     return toInitiatePaymentResponse(payment, snapToken);
   }
 
   static async verifyPayment(customerId: string, orderId: string): Promise<void> {
     const order = await fetchOrderForPayment(orderId);
     if (!order) throw new ResponseError(404, 'Order not found');
-    if (order.pickupRequest.customerId !== customerId)
-      throw new ResponseError(403, 'You are not authorized to verify this payment');
+    if (order.pickupRequest.customerId !== customerId) throw new ResponseError(403, 'You are not authorized to verify this payment');
     if (order.paymentStatus === 'PAID') return;
     if (!order.payment) throw new ResponseError(404, 'No payment initiated for this order');
-
-    const { transaction_status, fraud_status } =
-      await getCoreApi().transaction.status(order.payment.id);
-
-    if (transaction_status === 'settlement' && fraud_status !== 'deny')
-      await processSettlement(order.payment.id, orderId, order.status);
-    else if (transaction_status === 'expire')
-      await processFailure(order.payment.id, 'EXPIRED');
-    else if (transaction_status === 'cancel' || transaction_status === 'deny')
-      await processFailure(order.payment.id, 'FAILED');
+    const { transaction_status, fraud_status } = await getCoreApi().transaction.status(order.payment.id);
+    if (transaction_status === 'settlement' && fraud_status !== 'deny') await processSettlement(order.payment.id, orderId, order.status);
+    else if (transaction_status === 'expire') await processFailure(order.payment.id, 'EXPIRED');
+    else if (transaction_status === 'cancel' || transaction_status === 'deny') await processFailure(order.payment.id, 'FAILED');
   }
 
   static async handleWebhook(payload: MidtransWebhookPayload): Promise<void> {
-    if (!verifySignature(payload))
-      throw new ResponseError(400, 'Invalid signature');
-    const payment = await prisma.payment.findUnique({
-      where: { id: payload.order_id },
-      include: { order: true },
-    });
-    if (!payment) {
-      logger.warn(`Webhook received for unknown payment: ${payload.order_id}`);
-      return;
-    }
-    if (payment.status === 'PAID') {
-      logger.info(`Webhook duplicate for already-settled payment ${payment.id} — skipped`);
-      return;
-    }
-    if (parseFloat(payload.gross_amount) !== payment.amount) {
-      logger.warn(`Amount mismatch on webhook for payment ${payment.id}`);
-      throw new ResponseError(400, 'Invalid webhook payload');
-    }
-    const { transaction_status, fraud_status } = payload;
-    if (transaction_status === 'settlement' && fraud_status !== 'deny')
-      return void (await processSettlement(
-        payment.id,
-        payment.orderId,
-        payment.order.status,
-      ));
-    if (transaction_status === 'expire')
-      await processFailure(payment.id, 'EXPIRED');
-    else if (transaction_status === 'cancel' || transaction_status === 'deny')
-      await processFailure(payment.id, 'FAILED');
+    if (!verifySignature(payload)) throw new ResponseError(400, 'Invalid signature');
+    const payment = await prisma.payment.findUnique({ where: { id: payload.order_id }, include: { order: true } });
+    if (!payment) { logger.warn(`Webhook received for unknown payment: ${payload.order_id}`); return; }
+    if (payment.status === 'PAID') { logger.info(`Webhook duplicate for already-settled payment ${payment.id} — skipped`); return; }
+    if (parseFloat(payload.gross_amount) !== payment.amount) { logger.warn(`Amount mismatch on webhook for payment ${payment.id}`); throw new ResponseError(400, 'Invalid webhook payload'); }
+    await dispatchWebhookStatus(payload, payment.id, payment.orderId, payment.order.status);
   }
 }

--- a/src/features/pickup-requests/pickup-request-controller.ts
+++ b/src/features/pickup-requests/pickup-request-controller.ts
@@ -44,44 +44,15 @@ export class PickupRequestController {
   }
 
   static async accept(req: UserRequest, res: Response) {
-    if (!req.staff!.outletId) {
-      throw new ResponseError(409, 'Driver is not assigned to any outlet');
-    }
-
-    const pickupRequestId = Validation.validate(
-      PickupRequestValidation.ID_PARAM,
-      req.params.id
-    );
-    const response = await PickupRequestService.acceptPickupRequest(
-      req.staff!.id,
-      pickupRequestId,
-      req.staff!.outletId
-    );
-    res.json({
-      status: 'success',
-      message: 'Pickup request accepted',
-      data: response,
-    });
+    const pickupRequestId = Validation.validate(PickupRequestValidation.ID_PARAM, req.params.id);
+    const response = await PickupRequestService.acceptPickupRequest(req.staff!.id, pickupRequestId, req.staff!.outletId);
+    res.json({ status: 'success', message: 'Pickup request accepted', data: response });
   }
 
   static async complete(req: UserRequest, res: Response) {
-    if (!req.staff!.outletId) {
-      throw new ResponseError(409, 'Driver is not assigned to any outlet');
-    }
-
-    const pickupRequestId = Validation.validate(
-      PickupRequestValidation.ID_PARAM,
-      req.params.id
-    );
-    const response = await PickupRequestService.completePickupRequest(
-      req.staff!.id,
-      pickupRequestId
-    );
-    res.json({
-      status: 'success',
-      message: 'Pickup completed. Outlet admin notified.',
-      data: response,
-    });
+    const pickupRequestId = Validation.validate(PickupRequestValidation.ID_PARAM, req.params.id);
+    const response = await PickupRequestService.completePickupRequest(req.staff!.id, req.staff!.outletId, pickupRequestId);
+    res.json({ status: 'success', message: 'Pickup completed. Outlet admin notified.', data: response });
   }
 
   static async listHistory(req: UserRequest, res: Response) {

--- a/src/features/pickup-requests/pickup-request-model.ts
+++ b/src/features/pickup-requests/pickup-request-model.ts
@@ -41,26 +41,24 @@ export type CompletePickupRequestResponse = {
   orderStatus: OrderStatus;
 };
 
-export function toPickupRequestResponse(
-  pickupRequest: PickupRequest & { outlet: Outlet }
-): PickupRequestResponse {
-  return {
-    id: pickupRequest.id,
-    customerId: pickupRequest.customerId,
-    addressId: pickupRequest.addressId,
-    scheduledAt: pickupRequest.scheduledAt,
-    status: pickupRequest.status,
-    createdAt: pickupRequest.createdAt,
-    outlet: {
-      id: pickupRequest.outlet.id,
-      name: pickupRequest.outlet.name,
-      address: pickupRequest.outlet.address,
-      city: pickupRequest.outlet.city,
-      province: pickupRequest.outlet.province,
-      latitude: pickupRequest.outlet.latitude,
-      longitude: pickupRequest.outlet.longitude,
-    },
-  };
+function mapOutlet(outlet: Outlet): OutletInfo {
+  return { id: outlet.id, name: outlet.name, address: outlet.address, city: outlet.city, province: outlet.province, latitude: outlet.latitude, longitude: outlet.longitude };
+}
+
+function mapAddressInfo(address: Address): AddressInfo {
+  return { label: address.label, street: address.street, city: address.city, province: address.province, latitude: address.latitude, longitude: address.longitude, phone: address.phone };
+}
+
+function mapCustomerInfo(user: User): CustomerInfo {
+  return { id: user.id, name: user.name, phone: user.phone };
+}
+
+function mapPickupAddressInfo(address: Address): PickupAddressInfo {
+  return { label: address.label, street: address.street, city: address.city, phone: address.phone };
+}
+
+export function toPickupRequestResponse(pickupRequest: PickupRequest & { outlet: Outlet }): PickupRequestResponse {
+  return { id: pickupRequest.id, customerId: pickupRequest.customerId, addressId: pickupRequest.addressId, scheduledAt: pickupRequest.scheduledAt, status: pickupRequest.status, createdAt: pickupRequest.createdAt, outlet: mapOutlet(pickupRequest.outlet) };
 }
 
 export function toAcceptPickupRequestResponse(
@@ -108,32 +106,8 @@ export type PaginatedPickupRequestResponse = {
   meta: PaginationMeta;
 };
 
-export function toPickupRequestListItem(
-  pickupRequest: PickupRequest & { address: Address; customerUser: User }
-): PickupRequestListItem {
-  return {
-    id: pickupRequest.id,
-    customerId: pickupRequest.customerId,
-    addressId: pickupRequest.addressId,
-    outletId: pickupRequest.outletId,
-    scheduledAt: pickupRequest.scheduledAt,
-    status: pickupRequest.status,
-    createdAt: pickupRequest.createdAt,
-    address: {
-      label: pickupRequest.address.label,
-      street: pickupRequest.address.street,
-      city: pickupRequest.address.city,
-      province: pickupRequest.address.province,
-      latitude: pickupRequest.address.latitude,
-      longitude: pickupRequest.address.longitude,
-      phone: pickupRequest.address.phone,
-    },
-    customer: {
-      id: pickupRequest.customerUser.id,
-      name: pickupRequest.customerUser.name,
-      phone: pickupRequest.customerUser.phone,
-    },
-  };
+export function toPickupRequestListItem(pickupRequest: PickupRequest & { address: Address; customerUser: User }): PickupRequestListItem {
+  return { id: pickupRequest.id, customerId: pickupRequest.customerId, addressId: pickupRequest.addressId, outletId: pickupRequest.outletId, scheduledAt: pickupRequest.scheduledAt, status: pickupRequest.status, createdAt: pickupRequest.createdAt, address: mapAddressInfo(pickupRequest.address), customer: mapCustomerInfo(pickupRequest.customerUser) };
 }
 
 export type CustomerPickupListItem = {
@@ -182,25 +156,6 @@ export type PaginatedHistoryResponse = {
   meta: PaginationMeta;
 };
 
-export function toPickupHistoryItem(
-  pickupRequest: PickupRequest & {
-    address: Address;
-    customerUser: User;
-    order: Order | null;
-    updatedAt: Date;
-  }
-): PickupHistoryItem {
-  return {
-    id: pickupRequest.id,
-    orderId: pickupRequest.order?.id ?? null,
-    customerName: pickupRequest.customerUser.name,
-    pickupAddress: {
-      label: pickupRequest.address.label,
-      street: pickupRequest.address.street,
-      city: pickupRequest.address.city,
-      phone: pickupRequest.address.phone,
-    },
-    status: pickupRequest.status,
-    completedAt: pickupRequest.updatedAt,
-  };
+export function toPickupHistoryItem(pickupRequest: PickupRequest & { address: Address; customerUser: User; order: Order | null; updatedAt: Date }): PickupHistoryItem {
+  return { id: pickupRequest.id, orderId: pickupRequest.order?.id ?? null, customerName: pickupRequest.customerUser.name, pickupAddress: mapPickupAddressInfo(pickupRequest.address), status: pickupRequest.status, completedAt: pickupRequest.updatedAt };
 }

--- a/src/features/pickup-requests/pickup-request-service.ts
+++ b/src/features/pickup-requests/pickup-request-service.ts
@@ -53,25 +53,27 @@ async function advanceOrderStatus(tx: Prisma.TransactionClient, pickupRequestId:
     });
 }
 
+async function runAcceptPickupTx(tx: Prisma.TransactionClient, staffId: string, pickupRequestId: string, outletId: string) {
+  await checkDriverHasActiveTask(tx, staffId);
+  // Atomic update with status condition prevents concurrent accepts
+  const updated = await tx.pickupRequest
+    .update({ where: { id: pickupRequestId, status: PickupStatus.PENDING }, data: { driverId: staffId, status: PickupStatus.DRIVER_ASSIGNED } })
+    .catch(() => { throw new ResponseError(404, 'Pickup request not found or already assigned'); });
+  if (updated.outletId !== outletId) throw new ResponseError(403, 'Pickup request belongs to a different outlet');
+  await advanceOrderStatus(tx, pickupRequestId, OrderStatus.LAUNDRY_EN_ROUTE_TO_OUTLET);
+  return toAcceptPickupRequestResponse(updated as PickupRequest & { driverId: string }, OrderStatus.LAUNDRY_EN_ROUTE_TO_OUTLET);
+}
+
 export class PickupRequestService {
   static async createPickupRequest(customerId: string, input: CreatePickupRequestInput) {
     const address = await prisma.address.findUnique({ where: { id: input.addressId } });
     if (!address) throw new ResponseError(404, 'Address not found');
     if (address.userId !== customerId) throw new ResponseError(403, 'Forbidden');
-
-    const existingPickup = await prisma.pickupRequest.findFirst({
-      where: { customerId, addressId: input.addressId, scheduledAt: new Date(input.scheduledAt), status: PickupStatus.PENDING },
-    });
+    const existingPickup = await prisma.pickupRequest.findFirst({ where: { customerId, addressId: input.addressId, scheduledAt: new Date(input.scheduledAt), status: PickupStatus.PENDING } });
     if (existingPickup) throw new ResponseError(409, 'A pickup request for this address at this time already exists');
-
     const activeOutlets = await prisma.outlet.findMany({ where: { isActive: true } });
     const nearestOutlet = findNearestOutlet(activeOutlets, address.latitude, address.longitude);
-
-    const pickupRequest = await prisma.pickupRequest.create({
-      data: { customerId, addressId: input.addressId, outletId: nearestOutlet.id, scheduledAt: new Date(input.scheduledAt), status: PickupStatus.PENDING },
-      include: { outlet: true },
-    });
-
+    const pickupRequest = await prisma.pickupRequest.create({ data: { customerId, addressId: input.addressId, outletId: nearestOutlet.id, scheduledAt: new Date(input.scheduledAt), status: PickupStatus.PENDING }, include: { outlet: true } });
     return toPickupRequestResponse(pickupRequest);
   }
 
@@ -91,39 +93,19 @@ export class PickupRequestService {
     };
   }
 
-  static async acceptPickupRequest(staffId: string, pickupRequestId: string, outletId: string) {
-    return prisma.$transaction(async (tx) => {
-      await checkDriverHasActiveTask(tx, staffId);
-
-      // Atomic update with status condition prevents concurrent accepts
-      const updated = await tx.pickupRequest
-        .update({
-          where: { id: pickupRequestId, status: PickupStatus.PENDING },
-          data: { driverId: staffId, status: PickupStatus.DRIVER_ASSIGNED },
-        })
-        .catch(() => { throw new ResponseError(404, 'Pickup request not found or already assigned'); });
-
-      if (updated.outletId !== outletId) throw new ResponseError(403, 'Pickup request belongs to a different outlet');
-
-      await advanceOrderStatus(tx, pickupRequestId, OrderStatus.LAUNDRY_EN_ROUTE_TO_OUTLET);
-
-      return toAcceptPickupRequestResponse(
-        updated as PickupRequest & { driverId: string },
-        OrderStatus.LAUNDRY_EN_ROUTE_TO_OUTLET
-      );
-    });
+  static async acceptPickupRequest(staffId: string, pickupRequestId: string, outletId: string | null | undefined) {
+    if (!outletId) throw new ResponseError(409, 'Driver is not assigned to any outlet');
+    return prisma.$transaction((tx) => runAcceptPickupTx(tx, staffId, pickupRequestId, outletId));
   }
 
-  static async completePickupRequest(staffId: string, pickupRequestId: string) {
+  static async completePickupRequest(staffId: string, outletId: string | null | undefined, pickupRequestId: string) {
+    if (!outletId) throw new ResponseError(409, 'Driver is not assigned to any outlet');
     return prisma.$transaction(async (tx) => {
       const pickup = await tx.pickupRequest.findFirst({ where: { id: pickupRequestId, status: PickupStatus.DRIVER_ASSIGNED } });
-
       if (!pickup) throw new ResponseError(404, 'Pickup request not found or not in assigned state');
       if (pickup.driverId !== staffId) throw new ResponseError(403, 'You are not the assigned driver for this pickup');
-
       await tx.pickupRequest.update({ where: { id: pickupRequestId }, data: { status: PickupStatus.PICKED_UP } });
       await advanceOrderStatus(tx, pickupRequestId, OrderStatus.LAUNDRY_ARRIVED_AT_OUTLET);
-
       return { id: pickupRequestId, status: PickupStatus.PICKED_UP, orderStatus: OrderStatus.LAUNDRY_ARRIVED_AT_OUTLET };
     });
   }
@@ -149,21 +131,10 @@ export class PickupRequestService {
       ? { createdAt: { ...(query.fromDate && { gte: new Date(query.fromDate) }), ...(query.toDate && { lte: new Date(query.toDate) }) } }
       : {};
     const where = { driverId: staffId, status: PickupStatus.PICKED_UP, ...dateFilter };
-
     const [pickupRequests, total] = await prisma.$transaction([
-      prisma.pickupRequest.findMany({
-        where,
-        include: { address: true, customerUser: true, order: true },
-        orderBy: { [query.sortBy ?? 'createdAt']: query.order ?? 'desc' },
-        skip,
-        take: query.limit,
-      }),
+      prisma.pickupRequest.findMany({ where, include: { address: true, customerUser: true, order: true }, orderBy: { [query.sortBy ?? 'createdAt']: query.order ?? 'desc' }, skip, take: query.limit }),
       prisma.pickupRequest.count({ where }),
     ]);
-
-    return {
-      data: pickupRequests.map(toPickupHistoryItem),
-      meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) },
-    };
+    return { data: pickupRequests.map(toPickupHistoryItem), meta: { page: query.page, limit: query.limit, total, totalPages: Math.ceil(total / query.limit) } };
   }
 }

--- a/src/features/users/user-service.ts
+++ b/src/features/users/user-service.ts
@@ -46,6 +46,21 @@ const createCredentialAccount = async (userId: string, password: string) => {
   });
 };
 
+function fetchDashboardData(outletFilter: { outletId?: string }, startOfMonth: Date) {
+  return prisma.$transaction([
+    prisma.order.count({ where: outletFilter }),
+    prisma.outlet.count({ where: { isActive: true } }),
+    prisma.user.count({ where: { staff: null } }),
+    prisma.order.aggregate({ _sum: { totalPrice: true }, where: { ...outletFilter, paymentStatus: 'PAID', createdAt: { gte: startOfMonth } } }),
+    prisma.order.findMany({
+      where: outletFilter,
+      orderBy: { createdAt: 'desc' },
+      take: 5,
+      select: { id: true, status: true, createdAt: true, outlet: { select: { name: true } }, pickupRequest: { select: { customerUser: { select: { name: true } } } } },
+    }),
+  ]);
+}
+
 export class UserService {
   static async register(data: RegisterInput) {
     const existing = await prisma.user.findUnique({ where: { email: data.email } });
@@ -90,43 +105,14 @@ export class UserService {
 
   static async getDashboardStats(outletId: string | null): Promise<DashboardStatsResponse> {
     const outletFilter = outletId ? { outletId } : {};
-    const now = new Date();
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-
-    const [totalOrders, activeOutlets, registeredUsers, revenueResult, recentOrders] = await prisma.$transaction([
-      prisma.order.count({ where: outletFilter }),
-      prisma.outlet.count({ where: { isActive: true } }),
-      prisma.user.count({ where: { staff: null } }),
-      prisma.order.aggregate({
-        _sum: { totalPrice: true },
-        where: { ...outletFilter, paymentStatus: 'PAID', createdAt: { gte: startOfMonth } },
-      }),
-      prisma.order.findMany({
-        where: outletFilter,
-        orderBy: { createdAt: 'desc' },
-        take: 5,
-        select: {
-          id: true,
-          status: true,
-          createdAt: true,
-          outlet: { select: { name: true } },
-          pickupRequest: { select: { customerUser: { select: { name: true } } } },
-        },
-      }),
-    ]);
-
+    const startOfMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+    const [totalOrders, activeOutlets, registeredUsers, revenueResult, recentOrders] = await fetchDashboardData(outletFilter, startOfMonth);
     return {
       totalOrders,
       activeOutlets,
       registeredUsers,
       revenueMtd: revenueResult._sum.totalPrice ?? 0,
-      recentOrders: recentOrders.map((o) => ({
-        id: o.id,
-        customerName: o.pickupRequest.customerUser.name ?? 'Unknown',
-        status: o.status,
-        outletName: o.outlet.name,
-        createdAt: o.createdAt,
-      })),
+      recentOrders: recentOrders.map((o) => ({ id: o.id, customerName: o.pickupRequest.customerUser.name ?? 'Unknown', status: o.status, outletName: o.outlet.name, createdAt: o.createdAt })),
     };
   }
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -89,6 +89,7 @@ apiRouter.get('/worker/notifications/stream', requireStaffRole('WORKER'), Worker
 // history must be registered before /:id to prevent Express matching "history" as a UUID param
 apiRouter.get('/deliveries/history', requireStaffRole('DRIVER'), DeliveryController.listHistory);
 apiRouter.get('/deliveries', requireStaffRole('DRIVER'), DeliveryController.list);
+apiRouter.get('/deliveries/:id/order', requireStaffRole('DRIVER'), DeliveryController.getOrderSummary);
 apiRouter.patch('/deliveries/:id/accept', requireStaffRole('DRIVER'), DeliveryController.accept);
 apiRouter.patch('/deliveries/:id/complete', requireStaffRole('DRIVER'), DeliveryController.complete);
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -22,6 +22,7 @@ import { LaundryItemController } from '@/features/laundry-items/laundry-item-con
 import { ShiftController } from '@/features/shifts/shift-controller';
 import { DeliveryController } from '@/features/deliveries/delivery-controller';
 import { ComplaintController } from '@/features/complaints/complaint-controller';
+import { DriverController } from '@/features/driver/driver-controller';
 
 export const apiRouter = express.Router();
 
@@ -58,6 +59,8 @@ apiRouter.delete('/admin/users/:id', requireStaffRole('SUPER_ADMIN'), AdminUserC
 apiRouter.post('/shifts', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.create);
 apiRouter.get('/shifts', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.list);
 apiRouter.patch('/shifts/:id/end', requireStaffRole('SUPER_ADMIN', 'OUTLET_ADMIN'), ShiftController.end);
+
+apiRouter.get('/drivers/me/active-task', requireStaffRole('DRIVER'), DriverController.getActiveTask);
 
 apiRouter.post('/pickup-requests', requireCustomerAuth, PickupRequestController.create);
 apiRouter.get('/pickup-requests/my', requireCustomerAuth, PickupRequestController.listMy);

--- a/tests/unit/pickup-request-service.test.ts
+++ b/tests/unit/pickup-request-service.test.ts
@@ -234,6 +234,12 @@ describe('PickupRequestService.acceptPickupRequest', () => {
   const pickupId = '550e8400-e29b-41d4-a716-446655440004';
   const outletId = '550e8400-e29b-41d4-a716-446655440002';
 
+  it('throws 409 when driver has no outlet assigned', async () => {
+    await expect(
+      PickupRequestService.acceptPickupRequest(staffId, pickupId, null)
+    ).rejects.toMatchObject({ status: 409, message: 'Driver is not assigned to any outlet' });
+  });
+
   it('accepts pickup request and updates order status', async () => {
     pickupRequestMock.findFirst.mockResolvedValueOnce(null); // no active pickup
     deliveryMock.findFirst.mockResolvedValueOnce(null); // no active delivery
@@ -299,6 +305,13 @@ describe('PickupRequestService.acceptPickupRequest', () => {
 describe('PickupRequestService.completePickupRequest', () => {
   const staffId = '550e8400-e29b-41d4-a716-446655440001';
   const pickupId = '550e8400-e29b-41d4-a716-446655440004';
+  const outletId = '550e8400-e29b-41d4-a716-446655440002';
+
+  it('throws 409 when driver has no outlet assigned', async () => {
+    await expect(
+      PickupRequestService.completePickupRequest(staffId, null, pickupId)
+    ).rejects.toMatchObject({ status: 409, message: 'Driver is not assigned to any outlet' });
+  });
 
   it('marks pickup as PICKED_UP and updates order status', async () => {
     const pickup = makePickupRequest({ id: pickupId, status: 'DRIVER_ASSIGNED', driverId: staffId });
@@ -306,7 +319,7 @@ describe('PickupRequestService.completePickupRequest', () => {
     pickupRequestMock.update.mockResolvedValue({ ...pickup, status: 'PICKED_UP' } as never);
     orderMock.update.mockResolvedValue({} as never);
 
-    const result = await PickupRequestService.completePickupRequest(staffId, pickupId);
+    const result = await PickupRequestService.completePickupRequest(staffId, outletId, pickupId);
 
     expect(result.id).toBe(pickupId);
     expect(result.status).toBe('PICKED_UP');
@@ -320,7 +333,7 @@ describe('PickupRequestService.completePickupRequest', () => {
     pickupRequestMock.findFirst.mockResolvedValueOnce(null);
 
     await expect(
-      PickupRequestService.completePickupRequest(staffId, pickupId)
+      PickupRequestService.completePickupRequest(staffId, outletId, pickupId)
     ).rejects.toMatchObject({
       status: 404,
       message: 'Pickup request not found or not in assigned state',
@@ -333,7 +346,7 @@ describe('PickupRequestService.completePickupRequest', () => {
     pickupRequestMock.findFirst.mockResolvedValueOnce(pickup as never);
 
     await expect(
-      PickupRequestService.completePickupRequest(staffId, pickupId)
+      PickupRequestService.completePickupRequest(staffId, outletId, pickupId)
     ).rejects.toMatchObject({
       status: 403,
       message: 'You are not the assigned driver for this pickup',


### PR DESCRIPTION
## What changed
- Moved outlet assignment guard out of the controller and into `PickupRequestService.acceptPickupRequest` and `PickupRequestService.completePickupRequest`
- `completePickupRequest` signature updated: `outletId` is now the second parameter (before `pickupRequestId`) to keep outlet-check concerns co-located with the service entry point
- Extracted named helper functions across complaint, delivery, driver, payment, pickup-request, and user modules to bring function bodies within the 15-line limit and eliminate repeated inline object construction

## Why
The outlet check in the controller meant `PickupRequestService` could be called with a null outlet from any other call site — a job, another service, or a test — and proceed incorrectly. Moving the guard to the service ensures the invariant is enforced regardless of where the service is invoked.

## How to test
1. `npm test` — all unit tests pass, including two new 409 cases for the outlet guard
2. `npm run build` — TypeScript compilation passes with no errors
3. Manual: as a driver with no outlet assigned, call `PATCH /api/v1/pickup-requests/:id` → expect `409 Driver is not assigned to any outlet`
4. Manual: as a driver with no outlet assigned, call `PATCH /api/v1/pickup-requests/:id/complete` → expect `409 Driver is not assigned to any outlet`