### PR TITLE
fix: allow zero quantity in bypass requests

### DIFF
--- a/src/validations/bypass-request-validation.ts
+++ b/src/validations/bypass-request-validation.ts
@@ -18,7 +18,7 @@ export class BypassRequestValidation {
       .array(
         z.object({
           laundryItemId: z.uuid(),
-          quantity: z.number().int().positive(),
+          quantity: z.number().int().nonnegative(),
         })
       )
       .min(1),


### PR DESCRIPTION
## What changed
- Updated bypass request validation to allow non-negative item quantities.

## Why
Worker bypass requests must support missing-item mismatch cases where submitted quantity can be `0`.

## Verification
- `npm run build`
