### PR TITLE
fix: allow active station workers to submit work

### DIFF
--- a/src/features/bypass-requests/bypass-request-controller.ts
+++ b/src/features/bypass-requests/bypass-request-controller.ts
@@ -33,7 +33,7 @@ export class BypassRequestController {
       );
 
       const result = await BypassRequestService.create(
-        req.staff!.id,
+        req.staff!,
         orderId,
         station,
         request,
@@ -65,7 +65,7 @@ export class BypassRequestController {
       );
 
       const result = await BypassRequestService.create(
-        req.staff!.id,
+        req.staff!,
         orderId,
         station,
         request,

--- a/src/features/bypass-requests/bypass-request-helpers.ts
+++ b/src/features/bypass-requests/bypass-request-helpers.ts
@@ -10,7 +10,7 @@ import {
   StationStatus,
   StationType,
 } from '@/generated/prisma/client';
-import type { OrderStatus as OrderStatusType, Prisma, StationType as StationTypeValue } from '@/generated/prisma/client';
+import type { OrderStatus as OrderStatusType, Prisma, Staff, StationType as StationTypeValue } from '@/generated/prisma/client';
 
 export function prevStationFor(station: Exclude<StationTypeValue, 'WASHING'>): StationTypeValue {
   return station === StationType.IRONING ? StationType.WASHING : StationType.IRONING;
@@ -20,15 +20,15 @@ export async function loadStationRecord(
   tx: Prisma.TransactionClient,
   orderId: string,
   station: StationTypeValue,
-  workerId: string,
+  worker: Staff,
 ) {
   const sr = await tx.stationRecord.findUnique({
     where: { orderId_station: { orderId, station } },
-    include: { stationItems: true },
+    include: { order: true, stationItems: true },
   });
   if (!sr) throw new ResponseError(404, 'Station record not found');
-  if (sr.staffId !== workerId)
-    throw new ResponseError(403, 'You are not assigned to this station');
+  if (sr.order.outletId !== worker.outletId)
+    throw new ResponseError(403, 'You are not assigned to this outlet');
   return sr;
 }
 

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -9,6 +9,7 @@ import {
   toRejectBypassResponse,
   toBypassDetailResponse,
 } from './bypass-request-model';
+import type { Staff } from '@/generated/prisma/client';
 import { WorkerNotificationService } from '@/features/worker-notifications/worker-notification-service';
 import {
   advanceOrderStatus,
@@ -46,13 +47,13 @@ const BYPASS_DETAIL_INCLUDE = {
 
 export class BypassRequestService {
   static async create(
-    workerId: string,
+    worker: Staff,
     orderId: string,
     station: StationType,
     data: CreateBypassRequestInput,
   ) {
     return prisma.$transaction(async (tx) => {
-      const sr = await loadStationRecord(tx, orderId, station, workerId);
+      const sr = await loadStationRecord(tx, orderId, station, worker);
       const refItems = await fetchReferenceQuantities(tx, orderId, station);
       assertMismatch(refItems, data.items);
       await assertNoPendingBypass(tx, sr.id);
@@ -60,13 +61,16 @@ export class BypassRequestService {
       const bypass = await tx.bypassRequest.create({
         data: {
           stationRecordId: sr.id,
-          workerId,
+          workerId: worker.id,
           adminId: null,
           status: BypassStatus.PENDING,
           problemDescription: data.notes ?? null,
         },
       });
-      await tx.stationRecord.update({ where: { id: sr.id }, data: { status: StationStatus.BYPASS_REQUESTED } });
+      await tx.stationRecord.update({
+        where: { id: sr.id },
+        data: { staffId: worker.id, status: StationStatus.BYPASS_REQUESTED },
+      });
       return toBypassCreateResponse(bypass);
     });
   }

--- a/src/features/worker-orders/worker-order-helper.ts
+++ b/src/features/worker-orders/worker-order-helper.ts
@@ -96,7 +96,7 @@ export const loadWorkerStationRecordForProcess = async (
   tx: Prisma.TransactionClient,
   orderId: string,
   station: StationType,
-  workerId: string,
+  worker: Staff,
 ) => {
   const stationRecord = await tx.stationRecord.findUnique({
     where: { orderId_station: { orderId, station } },
@@ -110,8 +110,8 @@ export const loadWorkerStationRecordForProcess = async (
     throw new ResponseError(404, 'Station record not found');
   }
 
-  if (stationRecord.staffId !== workerId) {
-    throw new ResponseError(403, 'You are not assigned to this station');
+  if (stationRecord.order.outletId !== worker.outletId) {
+    throw new ResponseError(403, 'You are not assigned to this outlet');
   }
 
   return stationRecord;

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -53,7 +53,7 @@ export class WorkerOrderService {
         tx,
         orderId,
         queueContext.workerType,
-        staff.id,
+        staff,
       );
 
       if (stationRecord.status !== StationStatus.IN_PROGRESS) {
@@ -72,6 +72,7 @@ export class WorkerOrderService {
       const completedRecord = await tx.stationRecord.update({
         where: { id: stationRecord.id },
         data: {
+          staffId: staff.id,
           status: StationStatus.COMPLETED,
           completedAt: new Date(),
         },


### PR DESCRIPTION
## What changed
- Allowed active workers in the same outlet and station to submit station process and bypass requests.
- Updated the station record assignee to the worker who actually submits the work.

## Why
Worker dashboard shows station queue by outlet and station, but submit/bypass was still locked to the original `stationRecord.staffId`.
