### PR TITLE
fix: return staff id for shift creation

### DIFF
--- a/src/features/admin-users/admin-user-model.ts
+++ b/src/features/admin-users/admin-user-model.ts
@@ -15,6 +15,7 @@ export type UpdateAdminUserInput = {
 
 export type AdminUserResponse = {
   id: string;
+  staffId: string | null;
   name: string;
   email: string;
   emailVerified: boolean;
@@ -41,6 +42,7 @@ export function toAdminUserResponse(user: {
   emailVerified: boolean;
   createdAt: Date;
   staff: {
+    id: string;
     role: string;
     outletId: string | null;
     isActive: boolean;
@@ -50,6 +52,7 @@ export function toAdminUserResponse(user: {
 }): AdminUserResponse {
   return {
     id: user.id,
+    staffId: user.staff?.id ?? null,
     name: user.name ?? '',
     email: user.email,
     emailVerified: user.emailVerified,

--- a/src/features/admin-users/admin-user-service.ts
+++ b/src/features/admin-users/admin-user-service.ts
@@ -69,6 +69,7 @@ const fetchUsers = async (where: Prisma.StaffWhereInput, page: number, limit: nu
     toAdminUserResponse({
       ...staff.user,
       staff: {
+        id: staff.id,
         role: staff.role,
         outletId: staff.outletId,
         outlet: staff.outlet,
@@ -184,7 +185,14 @@ export class AdminUserService {
     return toAdminUserResponse({
       ...user,
       staff: staffRecord
-        ? { role: staffRecord.role, outletId: staffRecord.outletId, isActive: staffRecord.isActive, workerType: staffRecord.workerType, outlet: staffRecord.outlet }
+        ? {
+            id: staffRecord.id,
+            role: staffRecord.role,
+            outletId: staffRecord.outletId,
+            isActive: staffRecord.isActive,
+            workerType: staffRecord.workerType,
+            outlet: staffRecord.outlet,
+          }
         : null
     })
   }


### PR DESCRIPTION
## What changed
- added `staffId` to the admin user response payload
- updated admin user mapping so worker records expose both `user.id` and `staff.id`
- kept the existing user-management response shape intact for the rest of the fields

## Why
The shift creation endpoint expects a `staffId`, but the admin user list only returned `user.id`. Because of that mismatch, creating a shift from the admin dashboard failed even when the selected worker had no active shift.

## How to test
1. Run the backend and frontend apps.
2. Log in as `SUPER_ADMIN` or `OUTLET_ADMIN`.
3. Open `/admin/shifts`.
4. Click `Add Shift`.
5. Select a worker who does not currently have an active shift.
6. Pick a shift date and shift time.
7. Submit the form.
8. Verify the shift is created successfully.
