### PR TITLE
chore: add Vercel deployment config and HTTP cron endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ CLAUDE.md
 # Prisma
 .prisma/
 /src/generated/prisma
+.vercel
+.env*.local

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+tests/
+node_modules/
+.env*
+*.test.ts
+dist/

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,6 @@
+'use strict';
+const path = require('path');
+require('module-alias').addAlias('@', path.resolve(__dirname, '..', 'src'));
+require('dotenv/config');
+const { app } = require('../src/application/app');
+module.exports = app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
         "midtrans-client": "^1.4.3",
+        "module-alias": "^2.3.4",
         "node-cron": "^4.2.1",
         "nodemailer": "^8.0.1",
         "pg": "^8.19.0",
@@ -34,7 +35,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.3.5",
+        "@types/node": "^25.6.0",
         "@types/node-cron": "^3.0.11",
         "@types/nodemailer": "^7.0.11",
         "@types/pg": "^8.18.0",
@@ -50,6 +51,9 @@
         "tsc-alias": "^1.8.16",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -83,7 +87,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1842,7 +1845,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.5.tgz",
       "integrity": "sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
@@ -1958,7 +1960,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
       "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       }
@@ -1966,8 +1967,7 @@
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "peer": true
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -2018,8 +2018,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -2824,7 +2823,6 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.7.0.tgz",
       "integrity": "sha512-5Ar4OsZpJ54s21sy5oDNNW9gQtd4NuxCaiM7+JDTOU07D6VvlpLjYzAVCMB1+JzokN+08dAVomlx+b7bhJd3ww==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/client-runtime-utils": "7.7.0"
       },
@@ -3422,7 +3420,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4329,7 +4326,6 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
       "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -4432,7 +4428,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4989,7 +4984,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5414,7 +5410,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6096,7 +6091,6 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7168,7 +7162,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7245,7 +7238,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
       "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -7567,6 +7559,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/module-alias": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.3.4.tgz",
+      "integrity": "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7593,7 +7591,6 @@
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
@@ -7633,7 +7630,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -8155,7 +8151,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8484,7 +8479,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.7.0",
         "@prisma/dev": "0.24.3",
@@ -8980,7 +8974,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -9601,7 +9596,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9738,7 +9732,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10170,7 +10163,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "author": "Briand Alpa",
   "type": "commonjs",
   "main": "index.js",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "test": "jest",
-    "build": "tsc && tsc-alias",
+    "build": "prisma generate && tsc && tsc-alias",
+    "vercel-build": "prisma generate",
     "start": "node dist/main.js",
     "dev": "ts-node -r tsconfig-paths/register ./src/main.ts",
     "dev:watch": "nodemon"
@@ -27,6 +31,7 @@
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
     "midtrans-client": "^1.4.3",
+    "module-alias": "^2.3.4",
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.1",
     "pg": "^8.19.0",
@@ -42,7 +47,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.3.5",
+    "@types/node": "^25.6.0",
     "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.18.0",

--- a/src/features/cron/cron-controller.ts
+++ b/src/features/cron/cron-controller.ts
@@ -1,0 +1,37 @@
+import { NextFunction, Request, Response } from 'express';
+import { runAutoConfirm } from '@/jobs/auto-confirm.job';
+import { runPaymentDeadlineJob } from '@/jobs/payment-deadline.job';
+import { logger } from '@/application/logging';
+
+const verifyCronSecret = (req: Request, res: Response): boolean => {
+  const expected = process.env.CRON_SECRET;
+  if (!expected || req.headers.authorization !== `Bearer ${expected}`) {
+    res.status(401).json({ status: 'error', message: 'Unauthorized' });
+    return false;
+  }
+  return true;
+};
+
+export const CronController = {
+  autoConfirm: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!verifyCronSecret(req, res)) return;
+      await runAutoConfirm();
+      res.status(200).json({ status: 'success', message: 'Auto-confirm job completed' });
+    } catch (error) {
+      logger.error('Cron auto-confirm error', error);
+      next(error);
+    }
+  },
+
+  paymentDeadline: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!verifyCronSecret(req, res)) return;
+      await runPaymentDeadlineJob();
+      res.status(200).json({ status: 'success', message: 'Payment deadline job completed' });
+    } catch (error) {
+      logger.error('Cron payment-deadline error', error);
+      next(error);
+    }
+  },
+};

--- a/src/jobs/auto-confirm.job.ts
+++ b/src/jobs/auto-confirm.job.ts
@@ -4,7 +4,7 @@ import { logger } from '@/application/logging';
 
 const AUTO_CONFIRM_MS = 48 * 60 * 60 * 1000;
 
-const runAutoConfirm = async () => {
+export const runAutoConfirm = async () => {
   const threshold = new Date(Date.now() - AUTO_CONFIRM_MS);
   const result = await prisma.order.updateMany({
     where: { status: 'LAUNDRY_DELIVERED_TO_CUSTOMER', updatedAt: { lte: threshold } },

--- a/src/jobs/payment-deadline.job.ts
+++ b/src/jobs/payment-deadline.job.ts
@@ -120,6 +120,11 @@ const sendPaymentReminder = async () => {
   for (const order of orders) await notifyReminderOrder(order);
 };
 
+export const runPaymentDeadlineJob = async () => {
+  await sendPackingHeadsUp();
+  await sendPaymentReminder();
+};
+
 export const startPaymentDeadlineJob = () => {
   cron.schedule('*/30 * * * *', async () => {
     logger.info('Running payment deadline notification job');

--- a/src/routes/public-api.ts
+++ b/src/routes/public-api.ts
@@ -1,5 +1,6 @@
 import { UserController } from '@/features/users/user-controller';
 import { PaymentController } from '@/features/payments/payment-controller';
+import { CronController } from '@/features/cron/cron-controller';
 import express from 'express';
 
 export const publicRouter = express.Router();
@@ -9,3 +10,6 @@ publicRouter.post('/users/set-password', UserController.setPassword);
 publicRouter.post('/users/resend-verification', UserController.resendVerification);
 
 publicRouter.post('/payments/webhook', PaymentController.handleWebhook);
+
+publicRouter.get('/cron/auto-confirm', CronController.autoConfirm);
+publicRouter.get('/cron/payment-deadline', CronController.paymentDeadline);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` and `api/index.js` entry point for Vercel Node.js serverless deployment
- Expose cron jobs as authenticated HTTP endpoints (`/api/v1/cron/auto-confirm`, `/api/v1/cron/payment-deadline`) secured via `CRON_SECRET` Bearer token for use with Vercel Cron
- Export `runAutoConfirm` and `runPaymentDeadlineJob` from job files for HTTP invocation
- Add `module-alias` for `@/` path resolution in compiled output, `engines: node 22.x`, and `vercel-build` script

## Test plan
- [ ] Deploy to Vercel preview and verify app starts (GET / returns expected response)
- [ ] Call `GET /api/v1/cron/auto-confirm` with valid `Authorization: Bearer <CRON_SECRET>` → 200
- [ ] Call same endpoint without token → 401
- [ ] Call `GET /api/v1/cron/payment-deadline` with valid token → 200
- [ ] Confirm existing `npm test` and `npm run build` still pass locally