### PR TITLE
fix: stabilize deploy blocker tests and worker flows

### DIFF
--- a/src/features/shifts/shift-service.ts
+++ b/src/features/shifts/shift-service.ts
@@ -4,6 +4,11 @@ import { ResponseError } from '@/error/response-error';
 import { resolveManagedOutletId, toShiftResponse } from './shift-helper';
 import type { CreateShiftInput, ShiftListQuery } from './shift-model';
 
+const WORKER_INCLUDE = {
+  user: { select: { name: true } },
+  outlet: { select: { id: true, name: true } },
+} as const;
+
 const SHIFT_INCLUDE = {
   staff: { include: { user: { select: { name: true } } } },
   outlet: { select: { id: true, name: true } },
@@ -13,7 +18,7 @@ export class ShiftService {
   static async createShift(staff: Staff, data: CreateShiftInput) {
     const worker = await prisma.staff.findUnique({
       where: { id: data.staffId },
-      include: SHIFT_INCLUDE,
+      include: WORKER_INCLUDE,
     });
 
     if (!worker || worker.role !== 'WORKER' || !worker.outletId) {

--- a/src/features/worker-orders/worker-order-helper.ts
+++ b/src/features/worker-orders/worker-order-helper.ts
@@ -13,6 +13,7 @@ export const buildWorkerOrdersWhere = (
   query: WorkerOrderListQuery,
 ) => {
   const where: Record<string, unknown> = {
+    staffId: staff.id,
     station: staff.workerType,
     order: { outletId: staff.outletId },
   };
@@ -117,6 +118,10 @@ export const loadWorkerStationRecordForProcess = async (
 
   if (stationRecord.order.outletId !== worker.outletId) {
     throw new ResponseError(403, 'You are not assigned to this outlet');
+  }
+
+  if (stationRecord.staffId !== worker.id) {
+    throw new ResponseError(403, 'You are not assigned to this station record');
   }
 
   return stationRecord;

--- a/src/features/worker-orders/worker-order-query.ts
+++ b/src/features/worker-orders/worker-order-query.ts
@@ -66,6 +66,7 @@ export const getWorkerOrderDetail = async (staff: Staff, orderId: string) => {
 
   const record = await prisma.stationRecord.findFirst({
     where: {
+      staffId: staff.id,
       orderId,
       station: queueContext.workerType,
       order: { outletId: queueContext.outletId },

--- a/tests/integration/admin-routes.test.ts
+++ b/tests/integration/admin-routes.test.ts
@@ -9,11 +9,12 @@ jest.mock('better-auth/node', () => ({
 jest.mock('@/application/database', () => ({
   prisma: {
     user: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn(), count: jest.fn() },
-    staff: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn() },
+    staff: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     verification: { create: jest.fn(), deleteMany: jest.fn() },
     order: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), count: jest.fn() },
     orderItem: { create: jest.fn() },
     pickupRequest: { findMany: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
+    stationRecord: { create: jest.fn() },
     $transaction: jest.fn(),
   },
 }));
@@ -35,12 +36,17 @@ import { sendEmail } from '@/utils/mailer';
 import { auth } from '@/utils/auth';
 
 const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
+const mockTx = {
+  order: { create: jest.fn() },
+  stationRecord: { create: jest.fn() },
+  orderItem: { create: jest.fn() },
+};
 
 describe('Admin Routes Integration Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.$transaction as jest.Mock).mockImplementation(
-      (ops: Promise<unknown>[]) => Promise.all(ops)
+    (prisma.$transaction as jest.Mock).mockImplementation((input: any) =>
+      typeof input === 'function' ? input(mockTx) : Promise.all(input)
     );
   });
 
@@ -71,10 +77,24 @@ describe('Admin Routes Integration Tests', () => {
       (auth.api.getSession as unknown as jest.Mock).mockResolvedValue({ user: mockUser, session: 'token' });
       (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
       (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
-      (prisma.user.findMany as jest.Mock).mockResolvedValue([
-        { id: 'user-2', name: 'Alice', email: 'alice@example.com', emailVerified: true, createdAt: new Date(), staff: { role: 'OUTLET_ADMIN', outletId: null, isActive: true, workerType: null } },
+      (prisma.staff.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'staff-2',
+          role: 'OUTLET_ADMIN',
+          outletId: null,
+          isActive: true,
+          workerType: null,
+          outlet: null,
+          user: {
+            id: 'user-2',
+            name: 'Alice',
+            email: 'alice@example.com',
+            emailVerified: true,
+            createdAt: new Date(),
+          },
+        },
       ]);
-      (prisma.user.count as jest.Mock).mockResolvedValue(1);
+      (prisma.staff.count as jest.Mock).mockResolvedValue(1);
 
       const response = await request(app).get('/api/v1/admin/users');
 
@@ -539,8 +559,10 @@ describe('Admin Routes Integration Tests', () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
       (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
-      (prisma.order.create as jest.Mock).mockResolvedValue({ id: 'order-new', outletId: 'outlet-1' });
-      (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
+      mockTx.order.create.mockResolvedValue({ id: 'order-new', outletId: 'outlet-1', status: 'LAUNDRY_BEING_WASHED' });
+      mockTx.orderItem.create.mockResolvedValue({ id: 'item-1' });
+      (prisma.staff.findFirst as jest.Mock).mockResolvedValue({ id: 'staff-washing' });
+      mockTx.stationRecord.create.mockResolvedValue({ id: 'sr-1' });
 
       const response = await request(app).post('/api/v1/admin/orders').send(validBody);
 
@@ -616,8 +638,10 @@ describe('Admin Routes Integration Tests', () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
       (prisma.staff.findUnique as jest.Mock).mockResolvedValue(mockStaff);
       (prisma.pickupRequest.findUnique as jest.Mock).mockResolvedValue(mockPickup);
-      (prisma.order.create as jest.Mock).mockResolvedValue({ id: 'order-new', outletId: 'outlet-1' });
-      (prisma.orderItem.create as jest.Mock).mockResolvedValue({ id: 'item-1' });
+      mockTx.order.create.mockResolvedValue({ id: 'order-new', outletId: 'outlet-1', status: 'LAUNDRY_BEING_WASHED' });
+      mockTx.orderItem.create.mockResolvedValue({ id: 'item-1' });
+      (prisma.staff.findFirst as jest.Mock).mockResolvedValue({ id: 'staff-washing' });
+      mockTx.stationRecord.create.mockResolvedValue({ id: 'sr-1' });
 
       const response = await request(app).post('/api/v1/admin/orders').send(validBody);
 

--- a/tests/integration/worker-notification-routes.test.ts
+++ b/tests/integration/worker-notification-routes.test.ts
@@ -71,7 +71,7 @@ describe('Worker Notification Routes', () => {
     const response = await request(app).get('/api/v1/worker/notifications/stream');
 
     expect(response.status).toBe(422);
-    expect(response.body.errors).toBe(
+    expect(response.body.message).toBe(
       'Worker station or outlet assignment is not configured',
     );
   });

--- a/tests/unit/bypass-request-service.test.ts
+++ b/tests/unit/bypass-request-service.test.ts
@@ -6,6 +6,7 @@ const mockTx = {
   stationRecord: {
     findUnique: jest.fn(),
     update: jest.fn(),
+    create: jest.fn(),
   },
   orderItem: {
     findMany: jest.fn(),
@@ -40,6 +41,9 @@ jest.mock('@/application/database', () => ({
       findUnique: jest.fn(),
       count: jest.fn(),
     },
+    staff: {
+      findFirst: jest.fn(),
+    },
     orderItem: {
       findMany: jest.fn(),
     },
@@ -73,7 +77,11 @@ describe('BypassRequestService', () => {
   });
 
   describe('create', () => {
-    const workerId = 'worker-1';
+    const worker = {
+      id: 'worker-1',
+      outletId: 'outlet-1',
+      role: 'WORKER',
+    } as any;
     const orderId = 'order-1';
     const stationRecordId = 'sr-1';
 
@@ -81,7 +89,7 @@ describe('BypassRequestService', () => {
       mockTx.stationRecord.findUnique.mockResolvedValue(null);
 
       await expect(
-        BypassRequestService.create(workerId, orderId, 'WASHING', {
+        BypassRequestService.create(worker, orderId, 'WASHING', {
           items: [{ laundryItemId: 'item-1', quantity: 5 }],
         })
       ).rejects.toThrow(new ResponseError(404, 'Station record not found'));
@@ -92,16 +100,19 @@ describe('BypassRequestService', () => {
         id: stationRecordId,
         orderId,
         station: 'WASHING',
-        staffId: 'other-worker',
+        order: { outletId: 'outlet-1' },
         status: 'IN_PROGRESS',
         stationItems: [],
       });
+      mockTx.orderItem.findMany.mockResolvedValue([
+        { laundryItemId: 'item-1', quantity: 5 },
+      ]);
 
       await expect(
-        BypassRequestService.create(workerId, orderId, 'WASHING', {
+        BypassRequestService.create(worker, orderId, 'WASHING', {
           items: [{ laundryItemId: 'item-1', quantity: 5 }],
         })
-      ).rejects.toThrow(new ResponseError(403, 'You are not assigned to this station'));
+      ).rejects.toThrow(new ResponseError(400, 'No quantity mismatch detected'));
     });
 
     it('throws 400 when quantities match (no mismatch for WASHING)', async () => {
@@ -109,10 +120,13 @@ describe('BypassRequestService', () => {
         id: stationRecordId,
         orderId,
         station: 'WASHING',
-        staffId: workerId,
+        order: { outletId: 'outlet-1' },
         status: 'IN_PROGRESS',
         stationItems: [],
       });
+      mockTx.orderItem.findMany.mockResolvedValue([
+        { laundryItemId: 'item-1', quantity: 5 },
+      ]);
 
       mockTx.orderItem.findMany.mockResolvedValue([
         { laundryItemId: 'item-1', quantity: 5 },
@@ -120,7 +134,7 @@ describe('BypassRequestService', () => {
       ]);
 
       await expect(
-        BypassRequestService.create(workerId, orderId, 'WASHING', {
+        BypassRequestService.create(worker, orderId, 'WASHING', {
           items: [
             { laundryItemId: 'item-1', quantity: 5 },
             { laundryItemId: 'item-2', quantity: 3 },
@@ -134,7 +148,7 @@ describe('BypassRequestService', () => {
         id: stationRecordId,
         orderId,
         station: 'WASHING',
-        staffId: workerId,
+        order: { outletId: 'outlet-1' },
         status: 'IN_PROGRESS',
         stationItems: [],
       });
@@ -149,7 +163,7 @@ describe('BypassRequestService', () => {
       });
 
       await expect(
-        BypassRequestService.create(workerId, orderId, 'WASHING', {
+        BypassRequestService.create(worker, orderId, 'WASHING', {
           items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
         })
       ).rejects.toThrow(
@@ -162,7 +176,7 @@ describe('BypassRequestService', () => {
       const createdBypass = {
         id: 'bp-1',
         stationRecordId,
-        workerId,
+        workerId: worker.id,
         adminId: null,
         problemDescription: notes,
         status: 'PENDING',
@@ -173,7 +187,7 @@ describe('BypassRequestService', () => {
         id: stationRecordId,
         orderId,
         station: 'WASHING',
-        staffId: workerId,
+        order: { outletId: 'outlet-1' },
         status: 'IN_PROGRESS',
         stationItems: [],
       });
@@ -191,7 +205,7 @@ describe('BypassRequestService', () => {
         status: 'BYPASS_REQUESTED',
       });
 
-      const result = await BypassRequestService.create(workerId, orderId, 'WASHING', {
+      const result = await BypassRequestService.create(worker, orderId, 'WASHING', {
         items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
         notes,
       });
@@ -207,7 +221,7 @@ describe('BypassRequestService', () => {
       expect(mockTx.bypassRequest.create).toHaveBeenCalledWith({
         data: {
           stationRecordId,
-          workerId,
+          workerId: worker.id,
           adminId: null,
           status: 'PENDING',
           problemDescription: notes,
@@ -216,7 +230,7 @@ describe('BypassRequestService', () => {
 
       expect(mockTx.stationRecord.update).toHaveBeenCalledWith({
         where: { id: stationRecordId },
-        data: { status: 'BYPASS_REQUESTED' },
+        data: { staffId: worker.id, status: 'BYPASS_REQUESTED' },
       });
 
       expect(result).toEqual({
@@ -233,7 +247,7 @@ describe('BypassRequestService', () => {
           id: stationRecordId,
           orderId,
           station: 'IRONING',
-          staffId: workerId,
+          order: { outletId: 'outlet-1' },
           status: 'IN_PROGRESS',
           stationItems: [],
         })
@@ -250,7 +264,7 @@ describe('BypassRequestService', () => {
       mockTx.bypassRequest.create.mockResolvedValue({
         id: 'bp-1',
         stationRecordId,
-        workerId,
+        workerId: worker.id,
         adminId: null,
         problemDescription: null,
         status: 'PENDING',
@@ -258,7 +272,7 @@ describe('BypassRequestService', () => {
       });
       mockTx.stationRecord.update.mockResolvedValue({});
 
-      await BypassRequestService.create(workerId, orderId, 'IRONING', {
+      await BypassRequestService.create(worker, orderId, 'IRONING', {
         items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
       });
 
@@ -277,7 +291,7 @@ describe('BypassRequestService', () => {
           id: stationRecordId,
           orderId,
           station: 'PACKING',
-          staffId: workerId,
+          order: { outletId: 'outlet-1' },
           status: 'IN_PROGRESS',
           stationItems: [],
         })
@@ -294,7 +308,7 @@ describe('BypassRequestService', () => {
       mockTx.bypassRequest.create.mockResolvedValue({
         id: 'bp-1',
         stationRecordId,
-        workerId,
+        workerId: worker.id,
         adminId: null,
         problemDescription: null,
         status: 'PENDING',
@@ -302,7 +316,7 @@ describe('BypassRequestService', () => {
       });
       mockTx.stationRecord.update.mockResolvedValue({});
 
-      await BypassRequestService.create(workerId, orderId, 'PACKING', {
+      await BypassRequestService.create(worker, orderId, 'PACKING', {
         items: [{ laundryItemId: 'item-1', quantity: 3 }], // mismatch
       });
 
@@ -321,14 +335,14 @@ describe('BypassRequestService', () => {
           id: stationRecordId,
           orderId,
           station: 'IRONING',
-          staffId: workerId,
+          order: { outletId: 'outlet-1' },
           status: 'IN_PROGRESS',
           stationItems: [],
         })
         .mockResolvedValueOnce(null); // prev station missing
 
       await expect(
-        BypassRequestService.create(workerId, orderId, 'IRONING', {
+        BypassRequestService.create(worker, orderId, 'IRONING', {
           items: [{ laundryItemId: 'item-1', quantity: 3 }],
         })
       ).rejects.toThrow(
@@ -341,8 +355,9 @@ describe('BypassRequestService', () => {
     const makeBypass = (overrides = {}) => ({
       id: 'bp-1',
       stationRecord: {
-        station: 'IRONING',
+        station: 'WASHING',
         order: { id: 'ord-1', outletId: 'outlet-1' },
+        stationItems: [],
       },
       worker: { user: { name: 'Bob Ironing' } },
       admin: null,
@@ -355,6 +370,9 @@ describe('BypassRequestService', () => {
     it('SUPER_ADMIN: does not add outlet filter to where clause', async () => {
       (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypass()]);
       (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+      (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+        { laundryItemId: 'item-1', quantity: 5, laundryItem: { name: 'Shirt' } },
+      ]);
 
       await BypassRequestService.getAll('SUPER_ADMIN', undefined, {
         page: 1,
@@ -368,6 +386,9 @@ describe('BypassRequestService', () => {
     it('OUTLET_ADMIN with outletId: adds stationRecord.order.outletId filter', async () => {
       (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([makeBypass()]);
       (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+      (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+        { laundryItemId: 'item-1', quantity: 5, laundryItem: { name: 'Shirt' } },
+      ]);
 
       await BypassRequestService.getAll('OUTLET_ADMIN', 'outlet-1', {
         page: 1,
@@ -398,6 +419,9 @@ describe('BypassRequestService', () => {
       const bypass = makeBypass();
       (prisma.bypassRequest.findMany as jest.Mock).mockResolvedValue([bypass]);
       (prisma.bypassRequest.count as jest.Mock).mockResolvedValue(1);
+      (prisma.orderItem.findMany as jest.Mock).mockResolvedValue([
+        { laundryItemId: 'item-1', quantity: 5, laundryItem: { name: 'Shirt' } },
+      ]);
 
       const result = await BypassRequestService.getAll('SUPER_ADMIN', undefined, {
         page: 1,
@@ -409,7 +433,7 @@ describe('BypassRequestService', () => {
       expect(result.data[0]).toMatchObject({
         id: 'bp-1',
         orderId: 'ord-1',
-        station: 'IRONING',
+        station: 'WASHING',
         workerName: 'Bob Ironing',
         status: 'PENDING',
         resolvedAt: null,
@@ -455,9 +479,9 @@ describe('BypassRequestService', () => {
       id: bypassId,
       stationRecordId: 'sr-1',
       status,
-      stationRecord: {
-        order: { id: 'ord-1', status: orderStatus, paymentStatus, outletId: 'outlet-1' },
-      },
+        stationRecord: {
+          order: { id: 'ord-1', status: orderStatus, paymentStatus, outletId: 'outlet-1' },
+        },
     });
 
     const approve = (overrides: { role?: string; outletId?: string } = {}) =>
@@ -505,11 +529,14 @@ describe('BypassRequestService', () => {
     it('advances WASHING order to LAUNDRY_BEING_IRONED', async () => {
       const resolvedAt = new Date();
       mockTx.bypassRequest.findUnique.mockResolvedValue(makeBypass('PENDING', 'UNPAID', 'LAUNDRY_BEING_WASHED'));
+      mockTx.stationRecord.findUnique.mockResolvedValue(null);
       mockTx.bypassRequest.update.mockResolvedValue({
         id: bypassId, status: 'APPROVED', adminId: adminStaffId, problemDescription, resolvedAt,
       });
       mockTx.stationRecord.update.mockResolvedValue({});
       mockTx.order.update.mockResolvedValue({});
+      mockTx.stationRecord.create.mockResolvedValue({ id: 'sr-next' });
+      (prisma.staff.findFirst as jest.Mock).mockResolvedValue({ id: 'staff-ironing' });
 
       const result = await approve();
 
@@ -519,16 +546,27 @@ describe('BypassRequestService', () => {
         outletId: 'outlet-1',
         orderStatus: 'LAUNDRY_BEING_IRONED',
       });
+      expect(mockTx.stationRecord.create).toHaveBeenCalledWith({
+        data: {
+          orderId: 'ord-1',
+          station: 'IRONING',
+          staffId: 'staff-ironing',
+          status: 'IN_PROGRESS',
+        },
+      });
       expect(result.orderStatus).toBe('LAUNDRY_BEING_IRONED');
     });
 
     it('advances IRONING order to LAUNDRY_BEING_PACKED', async () => {
       mockTx.bypassRequest.findUnique.mockResolvedValue(makeBypass('PENDING', 'UNPAID', 'LAUNDRY_BEING_IRONED'));
+      mockTx.stationRecord.findUnique.mockResolvedValue(null);
       mockTx.bypassRequest.update.mockResolvedValue({
         id: bypassId, status: 'APPROVED', adminId: adminStaffId, problemDescription, resolvedAt: new Date(),
       });
       mockTx.stationRecord.update.mockResolvedValue({});
       mockTx.order.update.mockResolvedValue({});
+      mockTx.stationRecord.create.mockResolvedValue({ id: 'sr-next' });
+      (prisma.staff.findFirst as jest.Mock).mockResolvedValue({ id: 'staff-packing' });
 
       const result = await approve();
 
@@ -537,6 +575,14 @@ describe('BypassRequestService', () => {
         orderId: 'ord-1',
         outletId: 'outlet-1',
         orderStatus: 'LAUNDRY_BEING_PACKED',
+      });
+      expect(mockTx.stationRecord.create).toHaveBeenCalledWith({
+        data: {
+          orderId: 'ord-1',
+          station: 'PACKING',
+          staffId: 'staff-packing',
+          status: 'IN_PROGRESS',
+        },
       });
       expect(result.orderStatus).toBe('LAUNDRY_BEING_PACKED');
     });

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -246,6 +246,7 @@ describe('WorkerOrderService', () => {
 
     expect(prisma.stationRecord.findFirst).toHaveBeenCalledWith({
       where: {
+        staffId: 'staff-worker',
         orderId: 'order-1',
         station: 'WASHING',
         order: { outletId: 'outlet-1' },
@@ -432,6 +433,7 @@ describe('WorkerOrderService', () => {
     expect(mockTx.stationRecord.update).toHaveBeenCalledWith({
       where: { id: 'station-record-1' },
       data: {
+        staffId: 'staff-worker',
         status: 'COMPLETED',
         completedAt: expect.any(Date),
       },


### PR DESCRIPTION
## What changed
- fixed shift creation runtime failure by using the correct include shape when loading a worker staff record
- scoped worker order queries and detail access to the assigned worker staff id
- aligned backend integration and unit tests with the current worker and bypass behavior
- kept worker queue filtering focused on actionable station records for safer runtime behavior

## Why
These changes remove deploy blockers and runtime errors:
- `POST /api/v1/shifts` could fail with a Prisma include error at runtime
- worker accounts could still see or open station records not assigned to them
- backend tests needed to reflect the current response and worker flow logic

## Verification
- `npm run build`
- `npm test -- --runInBand`
- result: `46/46` test suites passed and `666/666` tests passed
