### PR TITLE
fix: assign station workers from active shifts

### DIFF
--- a/src/features/worker-orders/worker-order-helper.ts
+++ b/src/features/worker-orders/worker-order-helper.ts
@@ -131,22 +131,27 @@ export const findNextStationWorker = async (
   outletId: string,
   station: StationType,
 ) => {
-  const worker = await prisma.staff.findFirst({
+  const activeShift = await prisma.shift.findFirst({
     where: {
-      role: 'WORKER',
-      isActive: true,
       outletId,
-      workerType: station,
+      endTime: null,
+      staff: {
+        role: 'WORKER',
+        isActive: true,
+        outletId,
+        workerType: station,
+      },
     },
-    orderBy: { createdAt: 'asc' },
+    orderBy: { startTime: 'desc' },
+    include: { staff: true },
   });
 
-  if (!worker) {
+  if (!activeShift?.staff) {
     throw new ResponseError(
       422,
-      `No active worker configured for ${station} station`,
+      `No worker with an active shift is configured for ${station} station`,
     );
   }
 
-  return worker;
+  return activeShift.staff;
 };

--- a/tests/unit/worker-order-service.test.ts
+++ b/tests/unit/worker-order-service.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/application/database', () => ({
       count: jest.fn(),
       findFirst: jest.fn(),
     },
-    staff: {
+    shift: {
       findFirst: jest.fn(),
     },
     orderItem: {
@@ -406,8 +406,10 @@ describe('WorkerOrderService', () => {
     (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
       callback(mockTx),
     );
-    (prisma.staff.findFirst as jest.Mock).mockResolvedValue({
-      id: 'staff-ironing',
+    (prisma.shift.findFirst as jest.Mock).mockResolvedValue({
+      staff: {
+        id: 'staff-ironing',
+      },
     });
 
     const result = await WorkerOrderService.processWorkerOrder(
@@ -442,14 +444,19 @@ describe('WorkerOrderService', () => {
       where: { id: 'order-1' },
       data: { status: 'LAUNDRY_BEING_IRONED' },
     });
-    expect(prisma.staff.findFirst).toHaveBeenCalledWith({
+    expect(prisma.shift.findFirst).toHaveBeenCalledWith({
       where: {
-        role: 'WORKER',
-        isActive: true,
         outletId: 'outlet-1',
-        workerType: 'IRONING',
+        endTime: null,
+        staff: {
+          role: 'WORKER',
+          isActive: true,
+          outletId: 'outlet-1',
+          workerType: 'IRONING',
+        },
       },
-      orderBy: { createdAt: 'asc' },
+      orderBy: { startTime: 'desc' },
+      include: { staff: true },
     });
     expect(mockTx.stationRecord.create).toHaveBeenCalledWith({
       data: {
@@ -540,7 +547,7 @@ describe('WorkerOrderService', () => {
       data: { status: 'WAITING_FOR_PAYMENT' },
     });
     expect(mockTx.delivery.create).not.toHaveBeenCalled();
-    expect(prisma.staff.findFirst).not.toHaveBeenCalled();
+    expect(prisma.shift.findFirst).not.toHaveBeenCalled();
     expect(mockTx.stationRecord.create).not.toHaveBeenCalled();
     expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
       orderId: 'order-2',
@@ -626,7 +633,7 @@ describe('WorkerOrderService', () => {
       where: { id: 'order-3' },
       data: { status: 'LAUNDRY_READY_FOR_DELIVERY' },
     });
-    expect(prisma.staff.findFirst).not.toHaveBeenCalled();
+    expect(prisma.shift.findFirst).not.toHaveBeenCalled();
     expect(mockTx.stationRecord.create).not.toHaveBeenCalled();
     expect(WorkerNotificationService.publishOrderArrival).toHaveBeenCalledWith({
       orderId: 'order-3',


### PR DESCRIPTION
## What changed
- updated station worker assignment to select workers from active shifts instead of picking the earliest matching worker record
- required the assigned worker to match the outlet and station through the active shift relation
- updated the worker order unit test to match the new active-shift assignment behavior

## Why
During testing, newly created worker accounts could have the correct outlet and worker type but still not receive station work because the system picked the first matching worker in the outlet instead of the worker who was actually on an active shift.

## How to test
1. Log in as `SUPER_ADMIN` or `OUTLET_ADMIN`.
2. Create active shifts for one Washing worker, one Ironing worker, and one Packing worker.
3. Create a new pickup request as customer and complete pickup as driver.
4. Create an order as outlet admin.
5. Verify the order appears in the dashboard of the worker who has the active shift for the correct station.
6. Complete Washing and verify the order moves to the Ironing worker with an active shift.
7. Complete Ironing and verify the order moves to the Packing worker with an active shift.
