### PR TITLE
fix: enable trust proxy for Vercel proxy compatibility

### DIFF
--- a/src/application/app.ts
+++ b/src/application/app.ts
@@ -10,6 +10,10 @@ import rateLimit from 'express-rate-limit';
 
 export const app = express();
 
+// Vercel routes all requests through a proxy that sets X-Forwarded-For.
+// Trust one hop so express-rate-limit can correctly identify client IPs.
+app.set('trust proxy', 1);
+
 // Security headers first; sets X-Content-Type-Options, X-Frame-Options, HSTS, etc.
 app.use(helmet());
 


### PR DESCRIPTION
## Summary

- Add `app.set('trust proxy', 1)` to `src/application/app.ts`
- `express-rate-limit` v8 throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when Vercel's proxy sets `X-Forwarded-For` but Express `trust proxy` is not configured
- This caused every `/api/v1/*` route to return 500 before reaching any handler, including customer address listing and creation

## Test plan

- [ ] Deploy to Vercel (merge to main)
- [ ] Authenticate as a customer and call `GET /api/v1/users/addresses` — should return 200, not 500
- [ ] Call `POST /api/v1/users/addresses` with a valid address body — should return 201
- [ ] Confirm no `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` errors in Vercel runtime logs