### PR TITLE
fix: run prisma migrate deploy on vercel build and add directUrl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jest",
     "build": "prisma generate && tsc && tsc-alias",
-    "vercel-build": "prisma generate",
+    "vercel-build": "prisma migrate deploy && prisma generate",
     "start": "node dist/main.js",
     "dev": "ts-node -r tsconfig-paths/register ./src/main.ts",
     "dev:watch": "nodemon"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   },
   datasource: {
     url: process.env["DATABASE_URL"],
+    directUrl: process.env["DIRECT_URL"],
   },
 });


### PR DESCRIPTION
## Summary
- Run `prisma migrate deploy` as part of the Vercel build step so pending migrations are applied automatically on deployment
- Add `directUrl` to `prisma.config.ts` datasource to support connection pooler environments (Supabase + PgBouncer), which Prisma requires for running migrations

## Test plan
- [ ] Verify Vercel build completes without migration errors
- [ ] Confirm `DIRECT_URL` env var is set in Vercel project settings
- [ ] Confirm `DATABASE_URL` (pooled) and `DIRECT_URL` (direct) are both configured