### PR TITLE
fix: add migration for missing schema columns and vercel build config

### DIFF
--- a/prisma/migrations/20260429000000_add_missing_columns/migration.sql
+++ b/prisma/migrations/20260429000000_add_missing_columns/migration.sql
@@ -1,0 +1,9 @@
+-- addresses.phone and pickup_requests.updated_at were added via prisma db push
+-- and never captured in a migration file. This migration backfills them to
+-- bring the production schema in sync with the Prisma model.
+
+ALTER TABLE "addresses" ADD COLUMN "phone" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "addresses" ALTER COLUMN "phone" DROP DEFAULT;
+
+ALTER TABLE "pickup_requests" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "pickup_requests" ALTER COLUMN "updated_at" DROP DEFAULT;


### PR DESCRIPTION
## Summary

- Adds migration `20260429000000_add_missing_columns` to backfill `addresses.phone` and `pickup_requests.updated_at` — both columns were added via `prisma db push` locally and never captured in a migration file, causing consistent 500 errors on all address and pickup-request endpoints in production
- Updates `vercel-build` script to run `prisma migrate deploy && prisma generate` so the production DB schema is kept in sync on every deployment
- Adds `directUrl` to `prisma.config.ts` so the Prisma CLI uses the direct Neon connection for migrations while the runtime uses the pooled connection

## Test plan

- [ ] Verify Vercel build log shows `prisma migrate deploy` applying migration `20260429000000_add_missing_columns`
- [ ] Confirm `GET /api/v1/users/addresses` returns 200 in production after deployment
- [ ] Confirm `POST /api/v1/users/addresses` creates an address successfully in production
- [ ] Confirm `GET /api/v1/pickup-requests/my` no longer returns 500 in production