### PR TITLE
fix: remove seed from vercel-build and add TypeScript compile step

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jest",
     "build": "prisma generate && tsc && tsc-alias",
-    "vercel-build": "prisma migrate deploy && prisma generate && npx prisma db seed",
+    "vercel-build": "prisma migrate deploy && prisma generate && tsc && tsc-alias",
     "start": "node dist/main.js",
     "dev": "ts-node -r tsconfig-paths/register ./src/main.ts",
     "dev:watch": "nodemon"


### PR DESCRIPTION
## Summary
- Removes `npx prisma db seed` from `vercel-build` — seed uses `ts-node` (a devDependency) which is unavailable in Vercel's production build environment, causing the deployment to fail
- Adds `tsc && tsc-alias` to `vercel-build` so TypeScript is compiled and path aliases are resolved, producing the `dist/` output required by `npm start`

## Test plan
- [ ] Deploy to Vercel and verify build completes without error
- [ ] Confirm `dist/` is produced and the app starts correctly
- [ ] Run seed manually on production DB if initial data is needed: `DATABASE_URL=<prod-url> npx prisma db seed`