### PR TITLE
Bagus/refactor bypass request files

### DIFF
--- a/src/features/admin-orders/admin-order-service.ts
+++ b/src/features/admin-orders/admin-order-service.ts
@@ -22,6 +22,7 @@ const calculateDeliveryFee = (distanceKm: number) => {
 }
 
 const computeOrderPricing = (data: CreateAdminOrderInput, distanceKm: number) => {
+  // The final bill combines kilo-based laundry pricing, manual item pricing, and delivery fee.
   const laundryPrice = data.totalWeightKg * data.pricePerKg
   const deliveryFee = calculateDeliveryFee(distanceKm)
   return { deliveryFee, totalPrice: laundryPrice + deliveryFee + calculateOrderTotal(data) }
@@ -96,6 +97,7 @@ export class AdminOrderService {
   }
 
   static async createAdminOrder(staff: any, data: CreateAdminOrderInput) {
+    // Outlet admins can only turn a picked-up request into an order once, and only for their own outlet.
     const pickupRequest = await prisma.pickupRequest.findUnique({
       where: { id: data.pickupRequestId },
       include: { order: true, address: true, outlet: true },
@@ -118,6 +120,7 @@ export class AdminOrderService {
     )
     const { deliveryFee, totalPrice } = computeOrderPricing(data, distanceKm)
     const orderId = uuid()
+    // Order processing always starts in the washing station with the worker who is currently on an active shift.
     const washingWorker = await findNextStationWorker(pickupRequest.outletId, StationType.WASHING)
 
     const order = await prisma.$transaction(async (tx) => {

--- a/src/features/bypass-requests/bypass-request-model.ts
+++ b/src/features/bypass-requests/bypass-request-model.ts
@@ -103,19 +103,6 @@ type BypassWithRelations = Prisma.BypassRequestGetPayload<{
   };
 }>;
 
-type BypassWithDetailRelations = Prisma.BypassRequestGetPayload<{
-  include: {
-    stationRecord: {
-      include: {
-        order: true;
-        stationItems: { include: { laundryItem: true } };
-      };
-    };
-    worker: { include: { user: true } };
-    admin: { include: { user: true } };
-  };
-}>;
-
 export function toBypassCreateResponse(bypass: BypassRequest): BypassRequestCreateResponse {
   return {
     id: bypass.id,
@@ -125,7 +112,7 @@ export function toBypassCreateResponse(bypass: BypassRequest): BypassRequestCrea
 }
 
 const buildMismatchItems = (
-  bypass: BypassWithDetailRelations,
+  bypass: BypassWithRelations,
   referenceItems: BypassItemResponse[],
 ): BypassMismatchItemResponse[] => {
   const workerItems = new Map(
@@ -185,7 +172,7 @@ export function toRejectBypassResponse(bypass: BypassRequest): RejectBypassRespo
 }
 
 export function toBypassDetailResponse(
-  bypass: BypassWithDetailRelations,
+  bypass: BypassWithRelations,
   referenceItems: BypassItemResponse[]
 ): BypassRequestDetailResponse {
   const workerItems: BypassItemResponse[] = bypass.stationRecord.stationItems.map((item) => ({

--- a/src/features/bypass-requests/bypass-request-query.ts
+++ b/src/features/bypass-requests/bypass-request-query.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/application/database';
+
+export const BYPASS_LIST_INCLUDE = {
+  stationRecord: {
+    include: {
+      order: true,
+      stationItems: { include: { laundryItem: true } },
+    },
+  },
+  worker: { include: { user: true } },
+  admin: { include: { user: true } },
+} as const;
+
+export const BYPASS_DETAIL_INCLUDE = {
+  stationRecord: {
+    include: {
+      order: true,
+      stationItems: { include: { laundryItem: true } },
+    },
+  },
+  worker: { include: { user: true } },
+  admin: { include: { user: true } },
+} as const;
+
+export const getBypassList = (args: {
+  where: object;
+  order: 'asc' | 'desc';
+  page: number;
+  limit: number;
+}) => {
+  const { where, order, page, limit } = args;
+  return prisma.bypassRequest.findMany({
+    where,
+    include: BYPASS_LIST_INCLUDE,
+    orderBy: { createdAt: order },
+    skip: (page - 1) * limit,
+    take: limit,
+  });
+};
+
+export const getBypassDetail = (bypassId: string) =>
+  prisma.bypassRequest.findUnique({
+    where: { id: bypassId },
+    include: BYPASS_DETAIL_INCLUDE,
+  });

--- a/src/features/bypass-requests/bypass-request-service.ts
+++ b/src/features/bypass-requests/bypass-request-service.ts
@@ -27,6 +27,7 @@ import {
   saveStationItems,
   StationStatus,
 } from './bypass-request-helpers';
+import { getBypassDetail, getBypassList } from './bypass-request-query';
 import type { StationType } from '@/generated/prisma/client';
 import type { BypassListQuery } from '@/validations/bypass-request-validation';
 
@@ -35,6 +36,7 @@ const createNextStationRecord = async (
   order: { id: string; outletId: string },
   orderStatus: string,
 ) => {
+  // Approved bypasses should continue the order flow exactly like a successful station completion.
   const nextStation = resolveStationFromOrderStatus(orderStatus);
   if (!nextStation) return;
 
@@ -54,28 +56,6 @@ const createNextStationRecord = async (
   });
 };
 
-const BYPASS_LIST_INCLUDE = {
-  stationRecord: {
-    include: {
-      order: true,
-      stationItems: { include: { laundryItem: true } },
-    },
-  },
-  worker: { include: { user: true } },
-  admin: { include: { user: true } },
-} as const;
-
-const BYPASS_DETAIL_INCLUDE = {
-  stationRecord: {
-    include: {
-      order: true,
-      stationItems: { include: { laundryItem: true } },
-    },
-  },
-  worker: { include: { user: true } },
-  admin: { include: { user: true } },
-} as const;
-
 export class BypassRequestService {
   static async create(
     worker: Staff,
@@ -84,6 +64,7 @@ export class BypassRequestService {
     data: CreateBypassRequestInput,
   ) {
     return prisma.$transaction(async (tx) => {
+      // Workers can only request a bypass while they still own an in-progress station record.
       const sr = await loadStationRecord(tx, orderId, station, worker);
       if (sr.status !== StationStatus.IN_PROGRESS) {
         throw new ResponseError(409, 'Station is not in progress');
@@ -117,13 +98,7 @@ export class BypassRequestService {
     const { page, limit, status, order = 'desc' } = query;
     const where = buildBypassWhere(role, outletId, status);
     const [data, total] = await Promise.all([
-      prisma.bypassRequest.findMany({
-        where,
-        include: BYPASS_LIST_INCLUDE,
-        orderBy: { createdAt: order },
-        skip: (page - 1) * limit,
-        take: limit,
-      }),
+      getBypassList({ where, order, page, limit }),
       prisma.bypassRequest.count({ where }),
     ]);
     const responses = await Promise.all(
@@ -149,6 +124,7 @@ export class BypassRequestService {
     problemDescription: string,
   ) {
     const result = await prisma.$transaction(async (tx) => {
+      // Approve means accepting the mismatch, closing the current station, and moving the order forward.
       const bypass = await loadAndVerifyBypass(tx, admin, bypassId, password);
       const updated = await tx.bypassRequest.update({
         where: { id: bypassId },
@@ -183,6 +159,7 @@ export class BypassRequestService {
     password: string,
   ) {
     const result = await prisma.$transaction(async (tx) => {
+      // Reject sends the worker back to the same station so they can re-enter the quantities correctly.
       const bypass = await loadAndVerifyBypass(tx, admin, bypassId, password);
       const updated = await tx.bypassRequest.update({
         where: { id: bypassId },
@@ -211,10 +188,7 @@ export class BypassRequestService {
     outletId: string | null | undefined,
     bypassId: string,
   ) {
-    const bypass = await prisma.bypassRequest.findUnique({
-      where: { id: bypassId },
-      include: BYPASS_DETAIL_INCLUDE,
-    });
+    const bypass = await getBypassDetail(bypassId);
     if (!bypass) throw new ResponseError(404, 'Bypass request not found');
     assertOutletAccess(role, outletId, bypass.stationRecord.order.outletId);
     const referenceItems = await fetchReferenceItems(bypass.stationRecord.orderId, bypass.stationRecord.station);

--- a/src/features/shifts/shift-service.ts
+++ b/src/features/shifts/shift-service.ts
@@ -16,6 +16,7 @@ const SHIFT_INCLUDE = {
 
 export class ShiftService {
   static async createShift(staff: Staff, data: CreateShiftInput) {
+    // Shift creation is restricted to real worker staff records that belong to a managed outlet.
     const worker = await prisma.staff.findUnique({
       where: { id: data.staffId },
       include: WORKER_INCLUDE,
@@ -32,6 +33,7 @@ export class ShiftService {
     });
 
     if (activeShift) {
+      // Only one open shift is allowed for each worker so station assignment stays deterministic.
       throw new ResponseError(409, 'Worker already has an active shift');
     }
 
@@ -49,6 +51,7 @@ export class ShiftService {
   }
 
   static async getShifts(staff: Staff, query: ShiftListQuery) {
+    // Shift list access follows outlet scope so outlet admins only see workers from their own branch.
     const outletId = resolveManagedOutletId(staff, query.outletId);
     const where = {
       ...(outletId ? { outletId } : {}),
@@ -96,6 +99,7 @@ export class ShiftService {
     resolveManagedOutletId(staff, shift.outletId);
 
     if (shift.endTime) {
+      // Ending an already closed shift would create inconsistent worker availability state.
       throw new ResponseError(409, 'Shift has already ended');
     }
 

--- a/src/features/worker-orders/worker-order-service.ts
+++ b/src/features/worker-orders/worker-order-service.ts
@@ -46,6 +46,7 @@ export class WorkerOrderService {
     orderId: string,
     data: WorkerOrderProcessInput,
   ) {
+    // The worker queue context narrows processing to the station type that belongs to the logged-in worker.
     const queueContext = getWorkerQueueContext(staff);
 
     const result = await prisma.$transaction(async (tx) => {
@@ -65,6 +66,7 @@ export class WorkerOrderService {
         orderId,
         queueContext.workerType,
       );
+      // A normal station completion is only allowed when the worker re-enters the exact expected quantities.
       assertQuantitiesMatch(referenceItems, data.items);
 
       await saveStationItems(tx, stationRecord.id, data.items);
@@ -82,6 +84,7 @@ export class WorkerOrderService {
       const nextStation = resolveStationFromOrderStatus(nextOrderStatus);
 
       if (nextStation) {
+        // Each completed station hands the order to the next station worker who is currently on shift.
         const nextWorker = await findNextStationWorker(
           stationRecord.order.outletId,
           nextStation,


### PR DESCRIPTION
## What changed
- refactored the bypass request module so each bypass file now stays within the 200-line clean code limit
- moved bypass list/detail query includes into a dedicated `bypass-request-query.ts` file
- kept the existing bypass create, approve, reject, and detail flow unchanged

## Why
The bypass request module had files that exceeded the maximum 200-line guideline. This refactor keeps the flow easier to review and maintain without changing the business logic.

## How to test
1. Run `npm run build`.
2. Open the bypass request flow in the app.
3. Submit a worker bypass request.
4. Approve and reject a bypass request from the admin side.
5. Verify the behavior remains the same after the refactor.
