### PR TITLE
refactor: split admin user list query helpers

### DIFF
--- a/src/features/admin-users/admin-user-query.ts
+++ b/src/features/admin-users/admin-user-query.ts
@@ -1,0 +1,84 @@
+import { prisma } from '@/application/database'
+import { StaffRole } from '@/generated/prisma/enums'
+import type { Prisma } from '@/generated/prisma/client'
+import type { AdminUserResponse } from './admin-user-model'
+import { toAdminUserResponse } from './admin-user-model'
+
+const VALID_USER_SORT = ['createdAt', 'name', 'email'] as const
+type UserSortField = typeof VALID_USER_SORT[number]
+
+// Scopes user query by outlet and role. OUTLET_ADMIN sees only users from their outlet.
+export const buildUsersWhere = (
+  outletId: string | null | undefined,
+  role?: string,
+): Prisma.StaffWhereInput => {
+  const where: Prisma.StaffWhereInput = {}
+
+  // Admin user management only returns users that are actually staff accounts.
+  if (outletId) where.outletId = outletId
+  if (role) where.role = role as StaffRole
+
+  return where
+}
+
+export const fetchUsers = async (
+  where: Prisma.StaffWhereInput,
+  page: number,
+  limit: number,
+  sortBy = 'createdAt',
+  sortOrder = 'desc',
+) => {
+  const skip = (page - 1) * limit
+  // Allowlist sortBy to prevent probing internal field names via Prisma error messages.
+  const validSortBy: UserSortField = VALID_USER_SORT.includes(sortBy as UserSortField)
+    ? (sortBy as UserSortField)
+    : 'createdAt'
+  const validSortOrder = sortOrder === 'asc' ? 'asc' : 'desc'
+  const orderBy: Prisma.StaffOrderByWithRelationInput = validSortBy === 'createdAt'
+    ? { user: { createdAt: validSortOrder } }
+    : { user: { [validSortBy]: validSortOrder } }
+
+  const users = await prisma.staff.findMany({
+    where,
+    include: {
+      outlet: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          emailVerified: true,
+          createdAt: true,
+        },
+      },
+    },
+    orderBy,
+    skip,
+    take: limit,
+  })
+  const total = await prisma.staff.count({ where })
+
+  const data: AdminUserResponse[] = users.map((staff) =>
+    toAdminUserResponse({
+      ...staff.user,
+      staff: {
+        id: staff.id,
+        role: staff.role,
+        outletId: staff.outletId,
+        outlet: staff.outlet,
+        isActive: staff.isActive,
+        workerType: staff.workerType,
+      },
+    }),
+  )
+
+  return {
+    data,
+    meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+  }
+}

--- a/src/features/admin-users/admin-user-service.ts
+++ b/src/features/admin-users/admin-user-service.ts
@@ -1,89 +1,17 @@
 import { prisma } from '@/application/database'
 import { ResponseError } from '@/error/response-error'
-import { StaffRole } from '@/generated/prisma/enums'
 import { sendEmail } from '@/utils/mailer'
-import type { Prisma } from '@/generated/prisma/client'
 import { createHash } from 'crypto'
 import { v4 as uuid } from 'uuid'
 import {
   CreateAdminUserInput,
   GetAdminUsersQuery,
   UpdateAdminUserInput,
-  type AdminUserResponse,
   toAdminUserResponse
 } from './admin-user-model'
+import { buildUsersWhere, fetchUsers } from './admin-user-query'
 
-const hashToken = (token: string) => createHash('sha256').update(token).digest('hex');
-
-const VALID_USER_SORT = ['createdAt', 'name', 'email'] as const;
-type UserSortField = typeof VALID_USER_SORT[number];
-
-// Scopes user query by outlet and role. OUTLET_ADMIN sees only users from their outlet.
-const buildUsersWhere = (outletId: string | null | undefined, role?: string): Prisma.StaffWhereInput => {
-  const where: Prisma.StaffWhereInput = {}
-
-  // Admin user management only returns users that are actually staff accounts.
-  if (outletId) where.outletId = outletId
-  if (role) where.role = role as StaffRole
-
-  return where
-}
-
-const fetchUsers = async (where: Prisma.StaffWhereInput, page: number, limit: number, sortBy = 'createdAt', sortOrder = 'desc') => {
-  const skip = (page - 1) * limit
-  // Allowlist sortBy to prevent probing internal field names via Prisma error messages.
-  const validSortBy: UserSortField = VALID_USER_SORT.includes(sortBy as UserSortField)
-    ? (sortBy as UserSortField)
-    : 'createdAt'
-  const validSortOrder = sortOrder === 'asc' ? 'asc' : 'desc'
-  const orderBy: Prisma.StaffOrderByWithRelationInput = validSortBy === 'createdAt'
-    ? { user: { createdAt: validSortOrder } }
-    : { user: { [validSortBy]: validSortOrder } }
-
-  const users = await prisma.staff.findMany({
-    where,
-    include: {
-      outlet: {
-        select: {
-          id: true,
-          name: true,
-        },
-      },
-      user: {
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          emailVerified: true,
-          createdAt: true,
-        },
-      },
-    },
-    orderBy,
-    skip,
-    take: limit,
-  })
-  const total = await prisma.staff.count({ where })
-
-  const data: AdminUserResponse[] = users.map((staff) =>
-    toAdminUserResponse({
-      ...staff.user,
-      staff: {
-        id: staff.id,
-        role: staff.role,
-        outletId: staff.outletId,
-        outlet: staff.outlet,
-        isActive: staff.isActive,
-        workerType: staff.workerType,
-      },
-    })
-  )
-
-  return {
-    data,
-    meta: { page, limit, total, totalPages: Math.ceil(total / limit) }
-  }
-}
+const hashToken = (token: string) => createHash('sha256').update(token).digest('hex')
 
 const createUserAndStaff = async (data: CreateAdminUserInput) => {
 


### PR DESCRIPTION
## What changed
- moved admin user list query helpers into a dedicated `admin-user-query.ts` file
- extracted the outlet/role filter builder and paginated list fetch logic from `admin-user-service.ts`
- kept the existing create, update, delete, and invite flow unchanged

## Why
`admin-user-service.ts` exceeded the 200-line clean code limit. Splitting the list query helpers keeps the service focused on business actions while preserving the same behavior.

## How to test
1. Run `npm run build`.
2. Open the admin employee management page.
3. Verify the user list still loads with pagination, sorting, and role filtering.
4. Create, update, and delete an admin-managed user.
5. Confirm the flow behaves the same after the refactor.
