### PR TITLE
fix: tighten session cookie sameSite to lax

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -34,7 +34,7 @@ export const auth = betterAuth({
 
   advanced: {
     defaultCookieAttributes: {
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
     },
   },


### PR DESCRIPTION
## What changed

Changed `defaultCookieAttributes.sameSite` from `'none'` to `'lax'` in `src/utils/auth.ts`.

## Why

Previously `SameSite=None` was required because the frontend (`primecare-web.vercel.app`) and API (`primecare-api.vercel.app`) are on different origins, and cookies needed to be sent cross-site. Safari's ITP (Intelligent Tracking Prevention) blocks `SameSite=None` cookies in cross-site contexts, causing every request to `/api/v1/users/me` to return 401 after a successful sign-in on Safari (macOS and iOS) — while Chrome worked fine.

The fix in `primecare-web` adds a Vercel proxy rewrite so all `/api/*` requests are routed through the frontend domain. Cookies are now same-origin, making `SameSite=None` unnecessary. `SameSite=Lax` is the correct secure default: cookies are sent on same-origin requests and top-level navigations, but not on cross-site sub-resource requests (CSRF protection).

## How to test

1. Update `VITE_API_URL` in the `primecare-web` Vercel project environment variables to `https://primecare-web.vercel.app` and redeploy both projects.
2. Open Safari on macOS or iOS and navigate to the production URL.
3. Sign in with email and password — you should reach the dashboard without a 401 error.
4. Open Safari DevTools → Network tab and confirm auth requests go to `/api/auth/…` (same-origin, not `primecare-api.vercel.app` directly).
5. Repeat on Chrome to confirm no regression.
6. Check Vercel runtime logs for `primecare-api` — `GET /api/v1/users/me` should now return 200 instead of 401.